### PR TITLE
feat(script): Add PrecompileTools.jl pass to make the script more user friendly.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ version = "1.0.0"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 JuliaSyntax = "0.4.8"
+PrecompileTools = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -412,5 +412,6 @@ end
 
 include("runestone.jl")
 include("main.jl")
+include("precompiletools.jl")
 
 end # module

--- a/src/precompiletools.jl
+++ b/src/precompiletools.jl
@@ -1,0 +1,51 @@
+using PrecompileTools: @setup_workload, @compile_workload
+@setup_workload begin
+    bad_bad_code = """# Some ill-formatted julia code to fire-up Runic.jl!
+    # This is simply taken from runstone
+    print( "chaotic use of spaces (yes there's one space at the end of the line") 
+      
+    \tprint( "chaotic use of tabs")\t 
+    a = 0x1
+    b= 1.
+    c=1.00
+    d=0+2    
+
+
+    e=(
+    1,2,3,
+    4)
+    ( e...,)
+    a==3 ? println(   "foo") : nothing
+    struct     bar <:    Int
+    end
+    for i=1:1_000
+      nothing
+    end
+    function hello(::T) where T<:Int
+     println("No")
+        println("Indentation")
+    println("shall")
+     println("stop me.")
+        end
+    a  +
+      b
+    3+1:9*5
+    
+    """
+    filepath, io = mktemp()
+    write(io, bad_bad_code)
+    close(io)
+    @compile_workload begin
+        redirect_stdio(stdout = devnull, stderr = devnull) do
+            # Format this bad bad code
+            main(["-v", "-o", tempname(), filepath])
+            # Help print
+            main(["--help"])
+            # If git is available
+            git = Sys.which("git")
+            if !isnothing(git)
+                main(["--diff", "--check", filepath])
+            end
+        end
+    end
+end


### PR DESCRIPTION
Hi! I played with `Runic.jl` this afternoon and loved its simplicity of use. I don't know if you already accept contributions to this package but if you do, here's a simple change that makes it a bit smoother for the user. It simply adds a `PrecompileTools.jl` pass that fires the main function.


Before change:
```bash
$ time runic --help
...
julia -e 'using Runic; exit(Runic.main(ARGS))' -- --help  5.14s user 0.15s system 101% cpu 5.215 total
```

After:
```bash
$ time runic --help
...
julia -e 'using Runic; exit(Runic.main(ARGS))' -- --help  0.24s user 0.15s system 129% cpu 0.301 total
```