### PR TITLE
Rework indentation after assignment

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -724,8 +724,24 @@ end
             end
         end
         # assignment
-        for op in ("=", "+=")
-            @test format_string("a $(op)\n$(sp)b") == "a $(op)\n    b"
+        for nl in ("\n", "\n\n")
+            # Regular line continuation of newlines between `=` and rhs
+            for op in ("=", "+=", ".=", ".+=")
+                @test format_string("a $(op)$(nl)b") == "a $(op)$(nl)    b"
+                @test format_string("a $(op)$(nl)# comment$(nl)b") ==
+                    "a $(op)$(nl)    # comment$(nl)    b"
+            end
+            @test format_string("f(a) =$(nl)b") == "f(a) =$(nl)    b"
+            # Blocklike RHS
+            for thing in (
+                    "if c\n    x\nend", "try\n    x\ncatch\n    y\nend",
+                    "\"\"\"\nfoo\n\"\"\"", "r\"\"\"\nfoo\n\"\"\"",
+                    "```\nfoo\n```", "r```\nfoo\n```",
+                )
+                @test format_string("a =$(nl)$(thing)") == "a =$(nl)$(thing)"
+                @test format_string("a =$(nl)# comment$(nl)$(thing)") ==
+                    "a =$(nl)# comment$(nl)$(thing)"
+            end
         end
         # using/import
         for verb in ("using", "import")


### PR DESCRIPTION
This patch reworks the indentation after assignment. For "blocklike" (try/if/triple strings) right hand sides the indentation is disabled. Superfluous newlines are removed. For example

```julia
x =
if a
    x
else
    y
end
```

will become

```julia
x = if a
    x
else
    y
end
```

A valid alternative is

```julia
x = if a
        x
    else
        y
    end
```

This highlights the start/end of the right hand side of the assignment in a better way, but it doesn't look very nice and this style is never really seen in the wild. For triple strings I think it is OK though, e.g.

```julia
x = """
    foo
    bar
    """
```

vs the current (and seen more in the wild)

```julia
x = """
foo
bar
"""
```

Closes #39.