### PR TITLE
Implement `# runic: (off|on)` toggle comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,14 @@ exec 1>&2
 # Run Runic on added and modified files
 git diff-index -z --name-only --diff-filter=AM master | \
     grep -z '\.jl$' | \
-    xargs -0 --no-run-if-empty -p julia --project=@runic -m Runic --check --diff
+    xargs -0 --no-run-if-empty julia --project=@runic -m Runic --check --diff
 ```
 
 ## Formatting specification
 
 This is a list of things that Runic currently is doing:
 
+ - [Toggle formatting](#toggle-formatting)
  - [Line width limit](#line-width-limit)
  - [Indentation](#indentation)
  - [Spaces around operators, assignment, etc](#spaces-around-operators-assignment-etc)
@@ -252,6 +253,41 @@ This is a list of things that Runic currently is doing:
  - [`in` instead of `∈` and `=`](#in-instead-of--and-)
  - [Braces around right hand side of `where`](#braces-around-right-hand-side-of-where)
  - [Whitespace miscellaneous](#whitespace-miscellaneous)
+
+### Toggle formatting
+
+It is possible to toggle formatting around expressions where you want to disable Runic's
+formatting. This can be useful in cases where manual formatting increase the readability of
+the code. For example, manually aligned array literals may look worse when formatted by
+Runic.
+
+The source comments `# runic: off` and `# runic: on` will toggle the formatting off and on,
+respectively. The comments must be on their own line, they must be on the same level in the
+syntax tree, and they must come in pairs.
+
+> [!NOTE]
+> For compatibility with [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl) the
+> comments `#! format: off` and `#! format: on` are also recognized by Runic.
+
+For example, the following code will toggle off the formatting for the array literal `A`:
+
+```julia
+function foo()
+    a = rand(2)
+    # runic: off
+    A = [
+        -1.00   1.41
+         3.14  -4.05
+    ]
+    # runic: on
+    return A * a
+end
+```
+
+An exception to the pairing rule is made at top level where a `# runic: off` comment will
+disable formatting for the remainder of the file. This is so that a full file can be
+excluded from formatting without having to add a `# runic: on` comment at the end of the
+file.
 
 ### Line width limit
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -924,6 +924,68 @@ end
     end
 end
 
+@testset "# runic: (on|off)" begin
+    for exc in ("", "!"), word in ("runic", "format")
+        on = "#$(exc) $(word): on"
+        off = "#$(exc) $(word): off"
+        bon = "#$(exc == "" ? "!" : "") $(word): on"
+        # Disable rest of the file from top level comment
+        @test format_string("$off\n1+1") == "$off\n1+1"
+        @test format_string("1+1\n$off\n1+1") == "1 + 1\n$off\n1+1"
+        @test format_string("1+1\n$off\n1+1\n$on\n1+1") == "1 + 1\n$off\n1+1\n$on\n1 + 1"
+        @test format_string("1+1\n$off\n1+1\n$bon\n1+1") == "1 + 1\n$off\n1+1\n$bon\n1+1"
+        # Toggle inside a function
+        @test format_string(
+            """
+            function f()
+                $off
+                1+1
+                $on
+                1+1
+            end
+            """,
+        ) == """
+        function f()
+            $off
+            1+1
+            $on
+            1 + 1
+        end
+        """
+        @test format_string(
+            """
+            function f()
+                $off
+                1+1
+                $bon
+                1+1
+            end
+            """,
+        ) == """
+        function f()
+            $off
+            1 + 1
+            $bon
+            1 + 1
+        end
+        """
+        @test format_string(
+            """
+            function f()
+                $off
+                1+1
+                1+1
+            end
+            """,
+        ) == """
+        function f()
+            $off
+            1 + 1
+            1 + 1
+        end
+        """
+    end
+end
 
 const share_julia = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
 if Sys.isunix() && isdir(share_julia)


### PR DESCRIPTION
This patch implements `# runic: on` and `# runic: off` toggle comments that can be included in the source to toggle formatting on/off.

The two comments i) must be placed on their own lines, ii) must be on the same level in the expression tree, and iii) must come in pairs. An exception to condition iii) is made for top level toggle comments so that formatting for a whole file can be disabled by a `# runic: off` comment at the top without having to add one also at the end of the file.

For compatibility with JuliaFormatter, `#! format: (on|off)` is also
supported but it is not possible to pair e.g. a `# runic: off` comment
with a `#! format: on` comment.

Closes #12, closes #41.