### PR TITLE
Line continuation indent for triple-strings

### DIFF
--- a/src/chisels.jl
+++ b/src/chisels.jl
@@ -570,6 +570,11 @@ function is_triple_string_macro(node)
     return false
 end
 
+function is_triple_thing(node)
+    return is_triple_string(node) || is_triple_string_macro(node) ||
+        (kind(node) === K"juxtapose" && is_triple_string_macro(verified_kids(node)[1]))
+end
+
 ##########################
 # Utilities for IOBuffer #
 ##########################


### PR DESCRIPTION
This patch introduces line continuation based indent for triple strings,
which typically span multiple lines without any explicit newlines in the
syntax tree (since they are hidden inside the string).

This result in the following changes, some of which are clearly
bugfixes:

Operator chains:
```diff
 """
 abc
 """ * """
-def
-"""
+    def
+    """
```

Operator chain as assignment right hand side:
```diff
 x = """
-abc
-""" * """
-def
-"""
+    abc
+    """ * """
+    def
+    """
```

Implicit tuples:
```diff
 """
 abc
 """,
   """
-def
-"""
+    def
+    """
```

Note that single triple strings as a right hand side is excluded from
the indent rule, similar to having `if/try/let/...` blocks as a right
hand side.
