### PR TITLE
Drop trailing semicolons in block contexts

### DIFF
--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -421,6 +421,7 @@ function format_node!(ctx::Context, node::Node)::Union{Node, Nothing, NullNode}
     @return_something no_leading_and_single_trailing_newline(ctx, node)
     @return_something max_three_consecutive_newlines(ctx, node)
     @return_something insert_delete_mark_newlines(ctx, node)
+    @return_something remove_trailing_semicolon(ctx, node)
     @return_something trim_trailing_whitespace(ctx, node)
     @return_something format_hex_literals(ctx, node)
     @return_something format_float_literals(ctx, node)


### PR DESCRIPTION
This patch removes trailing semicolons in blocklike contexts (`for`, `if`, ...). Semicolons are left alone in top level contexts since they are sometimes used there for output suppression (e.g. Documenter examples or scripts that are copy-pasted/included in the REPL).

Semicolons before comments are replaced with a single space instead of removed so that if the comments are aligned before, they will be aligned after, for example
```julia
begin
    x = 1; # This is x
    y = 2  # This is y
end
```
will become
```julia
begin
    x = 1  # This is x
    y = 2  # This is y
end
```