### PR TITLE
Insert explicit return expressions in functions/macros/do-blocks

### DIFF
--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -48,4 +48,5 @@ function _show_green_node(io, node, indent, pos, str, show_trivia)
             p += x.span
         end
     end
+    return
 end

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -60,6 +60,7 @@ function Base.show(io::IO, ::MIME"text/plain", node::Node)
     show(io, node)
     println(io)
     _show_green_node(io, node, "", 1, nothing, true)
+    return
 end
 
 function Base.show(io::IO, node::Node)
@@ -136,6 +137,7 @@ mutable struct Context
     next_sibling::Union{Node, Nothing}
     # parent::Union{Node, Nothing}
     lineage_kinds::Vector{JuliaSyntax.Kind}
+    lineage_macros::Vector{String}
 end
 
 function Context(
@@ -166,11 +168,12 @@ function Context(
     call_depth = 0
     prev_sibling = next_sibling = nothing
     lineage_kinds = JuliaSyntax.Kind[]
+    lineage_macros = String[]
     format_on = true
     return Context(
         src_str, src_tree, src_io, fmt_io, fmt_tree, quiet, verbose, assert, debug, check,
         diff, filemode, indent_level, call_depth, format_on, prev_sibling, next_sibling,
-        lineage_kinds
+        lineage_kinds, lineage_macros
     )
 end
 
@@ -305,6 +308,9 @@ function format_node_with_kids!(ctx::Context, node::Node)
     ctx.prev_sibling = nothing
     ctx.next_sibling = nothing
     push!(ctx.lineage_kinds, kind(node))
+    if kind(node) === K"macrocall"
+        push!(ctx.lineage_macros, macrocall_name(ctx, node))
+    end
 
     # The new node parts. `kids′` aliases `kids` and only copied below if any of the
     # nodes change ("copy-on-write").
@@ -380,6 +386,9 @@ function format_node_with_kids!(ctx::Context, node::Node)
     ctx.prev_sibling = prev_sibling
     ctx.next_sibling = next_sibling
     pop!(ctx.lineage_kinds)
+    if kind(node) === K"macrocall"
+        pop!(ctx.lineage_macros)
+    end
     ctx.call_depth -= 1
     # Return a new node if any of the kids changed
     if any_kid_changed
@@ -435,6 +444,7 @@ function format_node!(ctx::Context, node::Node)::Union{Node, Nothing, NullNode}
     @return_something no_spaces_around_colon_etc(ctx, node)
     @return_something parens_around_op_calls_in_colon(ctx, node)
     @return_something for_loop_use_in(ctx, node)
+    @return_something explicit_return(ctx, node)
     @return_something braces_around_where_rhs(ctx, node)
     @return_something indent_multiline_strings(ctx, node)
     @return_something four_space_indent(ctx, node)

--- a/src/ToggleableAsserts.jl
+++ b/src/ToggleableAsserts.jl
@@ -30,7 +30,7 @@ assert_enabled() = true
 
 macro assert(expr)
     code = macroexpand_assert(expr)
-    :(assert_enabled() ? $(code) : nothing)
+    return :(assert_enabled() ? $(code) : nothing)
 end
 
 const toggle_lock = ReentrantLock()
@@ -41,4 +41,5 @@ function enable_assert(enable::Bool)
             @eval Runic assert_enabled() = $enable
         end
     end
+    return
 end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -20,6 +20,7 @@ function Base.showerror(io::IO, err::AssertionError)
             "please file an issue with a reproducible example at " *
             "https://github.com/fredrikekre/Runic.jl/issues/new."
     )
+    return
 end
 
 function macroexpand_assert(expr)

--- a/src/main.jl
+++ b/src/main.jl
@@ -424,6 +424,7 @@ function main(argv)
                 cmd = setenv(ignorestatus(cmd); dir = dir)
                 cmd = pipeline(cmd, stdout = stderr, stderr = stderr)
                 run_cmd(cmd)
+                return
             end
         end
 


### PR DESCRIPTION
This patch make sure that function definitions end with an explicit `return` statement before the last expression in the body.

If `for` or `while` is the last expression a `return nothing` node is inserted after the loop instead of `return for ...`.

`if`, `try`, `let`, and `begin` are currently are left as they are. Perhaps in the future Runic will recurse down into branches, or insert `return if` but for now this is left alone.

Another exception is also made whenever the last expression is a call to `throw` or `error` because it is pretty clear that the function will not return in this case (`return throw(...)` look silly).

Closes #43.