### PR TITLE
Trim trailing whitespace in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,10 +657,14 @@ Braces are consistently used around the right hand side of `where` expressions. 
 
 #### Trailing spaces
 
-Trailing spaces are removed. Example:
+Trailing spaces are removed in code and comments (but not inside of multiline strings where
+doing so would change the meaning of the code). Examples:
 ```diff
 -1 + 1 
 +1 + 1
+
+-x = 2 # x is two 
++x = 2 # x is two
 ```
 
 #### Tabs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,10 @@ end
     # Trailing whitespace just before closing indent token
     @test format_string("begin\n    a = 1 \nend") == "begin\n    a = 1\nend"
     @test format_string("let\n    a = 1 \nend") == "let\n    a = 1\nend"
+    # Trailing whitespace in comments
+    @test format_string("# comment ") == format_string("# comment  ") ==
+        format_string("# comment\t") == format_string("# comment\t\t") ==
+        format_string("# comment \t ") == format_string("# comment\t \t") == "# comment"
 end
 
 @testset "Hex/oct/bin literal integers" begin


### PR DESCRIPTION
This patch adds trimming of trailing whitespace inside of comments in addition to the trimming of trailing whitespace in code. Note that trailing whitespace inside of multiline is not trimmed since doing so would change the content of the string.

Closes #50.