### PR TITLE
Fix trailing comma in implicit tuples in destructuring

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -824,6 +824,10 @@ end
         # implicit tuple
         @test format_string("a,\n$(sp)b") == "a,\n    b"
         @test format_string("a,\n$(sp)b + \nb") == "a,\n    b +\n    b"
+        # implicit tuple in destructuring (LHS of K"=")
+        @test format_string("a,$(sp)=$(sp)z") == "a, = z"
+        @test format_string("a,$(sp)b$(sp)=$(sp)z") == "a, b = z"
+        @test format_string("a,$(sp)b$(sp),$(sp)=$(sp)z") == "a, b, = z"
         # K"cartesian_iterator"
         @test format_string("for i in I,\n$(sp)j in J\n# body\nend") ==
             "for i in I,\n        j in J\n    # body\nend"


### PR DESCRIPTION
This patch fixes the usage of trailing commas in implicit tuples when used in destructuring assignment, e.g. `x, = z`. In this context the trailing comma is needed to preserve the tuple node, which is different from e.g. implicit tuples in `do`-blocks. A trailing comma is allowed (e.g. preserved from the source) for multi-item implicit tuples so that e.g. `x, y, = z` can be used to signal that z contains more than two items. Closes #58.