### PR TITLE
Fix insertion of space before comment

### DIFF
--- a/src/chisels.jl
+++ b/src/chisels.jl
@@ -423,6 +423,21 @@ function replace_last_leaf(node::Node, kid′::Union{Node, NullNode})
     end
 end
 
+# Insert a node before the first leaf (at the same level)
+# TODO: Currently only works for inserting a space before a comment
+function add_before_first_leaf(node::Node, kid′::Union{Node, NullNode})
+    @assert !is_leaf(node)
+    kids = verified_kids(node)
+    @assert length(kids) > 0
+    kids′ = copy(kids)
+    if kind(kids′[1]) === K"Comment"
+        pushfirst!(kids′, kid′)
+    else
+        kids′[1] = add_before_first_leaf(kids′[1], kid′)
+    end
+    return make_node(node, kids′)
+end
+
 function last_leaf(node::Node)
     if is_leaf(node)
         return node

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,9 +83,10 @@ end
         @test format_string("1 + 1$(sp)# comment") == "1 + 1$(csp)# comment"
         @test format_string("(a,$(sp)# comment\nb)") ==
             "(\n    a,$(csp)# comment\n    b,\n)"
-        # Edgecase where the comment ends up as the first leaf inside the call
+        # Edgecases where the comment ends up as the first leaf inside a node
         @test format_string("(a,$(sp)# comment\nb + b)") ==
             "(\n    a,$(csp)# comment\n    b + b,\n)"
+        @test format_string("if c$(sp)# a\n    b\nend") == "if c$(csp)# a\n    b\nend"
     end
     let str = "a = 1  # a comment\nab = 2 # ab comment\n"
         @test format_string(str) == str


### PR DESCRIPTION
This patch changes where spaces are inserted before comments so that it is always added as a sibling to the comment instead of as a "uncle" when a comment is found as the first leaf of a kid.