### PR TITLE
Verify that Runic's output is parseable

### DIFF
--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -496,6 +496,13 @@ function format_tree!(ctx::Context)
     end
     # Truncate the output at the root span
     truncate(ctx.fmt_io, span(root′))
+    # Check that the output is parseable
+    try
+        fmt_str = String(read(seekstart(ctx.fmt_io)))
+        JuliaSyntax.parseall(JuliaSyntax.GreenNode, fmt_str; ignore_warnings = true, version = v"2-")
+    catch
+        throw(AssertionError("re-parsing the formatted output failed"))
+    end
     # Set the final tree
     ctx.fmt_tree = root′
     return nothing


### PR DESCRIPTION
This doesn't cost much (5 % perf hit for some large files) and can catch some errors. Note that it isn't possible/trivial to compare the trees since the formatter make changes to it.