### PR TITLE
Don't use spaces around `..`

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ arguments in function definitions and calls. Examples:
 +foo(a = 1)
 ```
 
-Exceptions to the rule above are `:`, `^`, `::`, and unary `<:` and `>:`. These are
+Exceptions to the rule above are `:`, `..`, `^`, `::`, and unary `<:` and `>:`. These are
 formatted *without* spaces around them. Examples:
 ```diff
 -a : b

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -802,7 +802,7 @@ end
 # <: and >: operators.
 function spaces_around_operators(ctx::Context, node::Node)
     if !(
-            (is_infix_op_call(node) && !(kind(infix_op_call_op(node)) in KSet": ^")) ||
+            (is_infix_op_call(node) && !(kind(infix_op_call_op(node)) in KSet": .. ^")) ||
                 (kind(node) in KSet"<: >:" && meta_nargs(node) == 3) ||
                 (kind(node) === K"comparison" && !JuliaSyntax.is_trivia(node))
         )
@@ -1205,17 +1205,17 @@ function spaces_in_import_using(ctx::Context, node::Node)
     end
 end
 
-# no spaces around `:`, `^`, and `::`
+# no spaces around `:`, `..`, `^`, and `::`
 function no_spaces_around_colon_etc(ctx::Context, node::Node)
     if !(
-            (is_infix_op_call(node) && kind(infix_op_call_op(node)) in KSet": ^") ||
+            (is_infix_op_call(node) && kind(infix_op_call_op(node)) in KSet": .. ^") ||
                 (kind(node) === K"::" && !is_leaf(node)) ||
                 (kind(node) in KSet"<: >:" && meta_nargs(node) == 2)
         )
         return nothing
     end
     @assert kind(node) in KSet"call :: <: >:"
-    is_x = x -> is_leaf(x) && kind(x) in KSet": ^ :: <: >:"
+    is_x = x -> is_leaf(x) && kind(x) in KSet": .. ^ :: <: >:"
     return no_spaces_around_x(ctx, node, is_x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,7 +180,7 @@ end
             @test format_string("$(sp)a$(sp)$(op)$(sp)# comment\nb$(sp)") ==
                 "$(sp)a $(op) # comment\n    b$(sp)"
         end
-        # Exceptions to the rule: `:` and `^`
+        # Exceptions to the rule: `:`, `..`, and `^`
         # a:b
         @test format_string("$(sp)a$(sp):$(sp)b$(sp)") == "$(sp)a:b$(sp)"
         @test format_string("$(sp)a + a$(sp):$(sp)b + b$(sp)") == "$(sp)(a + a):(b + b)$(sp)"
@@ -190,6 +190,8 @@ end
         @test format_string("$(sp)a$(sp):$(sp)b$(sp):$(sp)c$(sp)") == "$(sp)a:b:c$(sp)"
         @test format_string("$(sp)(1 + 2)$(sp):$(sp)(1 + 3)$(sp):$(sp)(1 + 4)$(sp)") ==
             "$(sp)(1 + 2):(1 + 3):(1 + 4)$(sp)"
+        # a..b
+        @test format_string("$(sp)a$(sp)..$(sp)b$(sp)") == "$(sp)a..b$(sp)"
         # a^b
         @test format_string("$(sp)a$(sp)^$(sp)b$(sp)") == "$(sp)a^b$(sp)"
         # Edgecase when formatting whitespace in the next leaf, when the next leaf is a


### PR DESCRIPTION
`..` is typically used similarly to `:` which is already excluded from the space-around-operator rule.