### PR TITLE
Relax toggle comments to allow more "pragmas"

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,16 @@ Runic.
 
 The source comments `# runic: off` and `# runic: on` will toggle the formatting off and on,
 respectively. The comments must be on their own line, they must be on the same level in the
-syntax tree, and they must come in pairs.
+syntax tree, and they must come in pairs. An exception to the pairing rule is made at top
+level where a `# runic: off` comment will disable formatting for the remainder of the file.
+This is so that a full file can be excluded from formatting without having to add a
+`# runic: on` comment at the end of the file.
+
+> [!NOTE]
+> Note that it is enough that a comment contain the substring `# runic: off` or
+> `# runic: on` so that they can be combined with other "pragmas" such as e.g.
+> [Literate.jl line filters](https://fredrikekre.github.io/Literate.jl/v2/fileformat/#Filtering-lines)
+> like `#src`.
 
 > [!NOTE]
 > For compatibility with [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl) the
@@ -338,11 +347,6 @@ function foo()
     return A * a
 end
 ```
-
-An exception to the pairing rule is made at top level where a `# runic: off` comment will
-disable formatting for the remainder of the file. This is so that a full file can be
-excluded from formatting without having to add a `# runic: on` comment at the end of the
-file.
 
 ### Line width limit
 

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -231,7 +231,7 @@ function check_format_toggle(ctx::Context, node::Node, kid::Node, i::Int)::Union
     # Check if the kid is a comment
     kind(kid) === K"Comment" || return nothing
     # Check the comment content
-    reg = r"^#(!)? (runic|format): (on|off)$"
+    reg = r"#(!)? (runic|format): (on|off)"
     str = String(read_bytes(ctx, kid))
     offmatch = match(reg, str)
     offmatch === nothing && return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1442,6 +1442,11 @@ end
                 return
             end
             """
+        # Extra stuff in the toggle comments
+        @test format_string("1+1\n$off #src\n1+1\n$on #src\n1+1") ==
+            "1 + 1\n$off #src\n1+1\n$on #src\n1 + 1"
+        @test format_string("1+1\n#src $off\n1+1\n#src $on\n1+1") ==
+            "1 + 1\n#src $off\n1+1\n#src $on\n1 + 1"
     end
 end
 


### PR DESCRIPTION
This patch relaxes the toggle comments `# runic: (off|on)` such that the comment may contain more than just the toggle comment. This is useful when combining with other "pragmas" such as e.g. Literate.jl line filters. For example, the following now also toggles formatting:

```julia
# runic: off      #src
not = formatted   #src
# runic: on       #src
```