### PR TITLE
Revert "Don't use spaces around `..` (#74)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ arguments in function definitions and calls. Examples:
 +foo(a = 1)
 ```
 
-Exceptions to the rule above are `:`, `..`, `^`, `::`, and unary `<:` and `>:`. These are
+Exceptions to the rule above are `:`, `^`, `::`, and unary `<:` and `>:`. These are
 formatted *without* spaces around them. Examples:
 ```diff
 -a : b

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -805,7 +805,7 @@ end
 # <: and >: operators.
 function spaces_around_operators(ctx::Context, node::Node)
     if !(
-            (is_infix_op_call(node) && !(kind(infix_op_call_op(node)) in KSet": .. ^")) ||
+            (is_infix_op_call(node) && !(kind(infix_op_call_op(node)) in KSet": ^")) ||
                 (kind(node) in KSet"<: >:" && meta_nargs(node) == 3) ||
                 (kind(node) === K"comparison" && !JuliaSyntax.is_trivia(node))
         )
@@ -1211,17 +1211,17 @@ function spaces_in_import_using(ctx::Context, node::Node)
     end
 end
 
-# no spaces around `:`, `..`, `^`, and `::`
+# no spaces around `:`, `^`, and `::`
 function no_spaces_around_colon_etc(ctx::Context, node::Node)
     if !(
-            (is_infix_op_call(node) && kind(infix_op_call_op(node)) in KSet": .. ^") ||
+            (is_infix_op_call(node) && kind(infix_op_call_op(node)) in KSet": ^") ||
                 (kind(node) === K"::" && !is_leaf(node)) ||
                 (kind(node) in KSet"<: >:" && meta_nargs(node) == 2)
         )
         return nothing
     end
     @assert kind(node) in KSet"call :: <: >:"
-    is_x = x -> is_leaf(x) && kind(x) in KSet": .. ^ :: <: >:"
+    is_x = x -> is_leaf(x) && kind(x) in KSet": ^ :: <: >:"
     return no_spaces_around_x(ctx, node, is_x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,7 +186,7 @@ end
             @test format_string("$(sp)a$(sp)$(op)$(sp)# comment\nb$(sp)") ==
                 "$(sp)a $(op)$(minspace)# comment\n    b$(sp)"
         end
-        # Exceptions to the rule: `:`, `..`, and `^`
+        # Exceptions to the rule: `:` and `^`
         # a:b
         @test format_string("$(sp)a$(sp):$(sp)b$(sp)") == "$(sp)a:b$(sp)"
         @test format_string("$(sp)a + a$(sp):$(sp)b + b$(sp)") == "$(sp)(a + a):(b + b)$(sp)"
@@ -196,8 +196,6 @@ end
         @test format_string("$(sp)a$(sp):$(sp)b$(sp):$(sp)c$(sp)") == "$(sp)a:b:c$(sp)"
         @test format_string("$(sp)(1 + 2)$(sp):$(sp)(1 + 3)$(sp):$(sp)(1 + 4)$(sp)") ==
             "$(sp)(1 + 2):(1 + 3):(1 + 4)$(sp)"
-        # a..b
-        @test format_string("$(sp)a$(sp)..$(sp)b$(sp)") == "$(sp)a..b$(sp)"
         # a^b
         @test format_string("$(sp)a$(sp)^$(sp)b$(sp)") == "$(sp)a^b$(sp)"
         # Edgecase when formatting whitespace in the next leaf, when the next leaf is a


### PR DESCRIPTION
Behavior of `..` is more tricky than `:`. Sometimes the space is
required like in e.g. `a .. -b` which, formatted as `a..-b`, would give
`ParseError: invalid operator ..-`.

This reverts commit 7d26dcf2687fc148e5cc038295351ef204e101e2.
