### PR TITLE
Fix extra space in export/public/global/local multiline lists

### DIFF
--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -992,7 +992,7 @@ function spaces_in_export_public(ctx::Context, node::Node)
             elseif kind(kid) in KSet"Comment NewlineWs"
                 any_changes && push!(kids′, kid)
                 accept_node!(ctx, kid)
-                state = :expect_space
+                state = kind(kid) === K"Comment" ? (:expect_space) : (:expect_identifier)
             else
                 unreachable()
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -993,6 +993,7 @@ end
         @test format_string("$(verb) a$(sp),$(sp)#= b, =#$(sp)c") == "$(verb) a, #= b, =# c"
         # https://github.com/fredrikekre/Runic.jl/issues/78
         @test format_string("$(verb)\n    #a\n    a,\n\n    #b\nb") == "$(verb)\n    #a\n    a,\n\n    #b\n    b"
+        @test format_string("$(verb) $(sp)a,$(sp)\n\n$(sp)b") == "$(verb) a,\n\n    b"
     end
     # Interpolated identifiers (currently only expected in K"quote" and K"macrocall")
     @test format_string(":(export \$a)") == ":(export \$a)"


### PR DESCRIPTION
Same issue as in #78, with same fix as in #83, but for a different
edgecase.
