### PR TITLE
Consistently use single space after `function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased changes
+### Changed
+ - Fix a bug that caused "single space after keyword" to not apply after the `function`
+   keyword in non-standard function definitions. ([#113])
+
 ## [v1.0.1] - 2024-11-28
 ### Fixed
  - Fix an incorrect whitespace assertion in function indentation ([#109], [#110]).
@@ -19,3 +24,4 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [v1.0.1]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.0.1
 [#109]: https://github.com/fredrikekre/Runic.jl/issues/109
 [#110]: https://github.com/fredrikekre/Runic.jl/issues/110
+[#113]: https://github.com/fredrikekre/Runic.jl/issues/113

--- a/src/chisels.jl
+++ b/src/chisels.jl
@@ -581,39 +581,6 @@ function unwrap_to_call_or_tuple(x)
     return unwrap_to_call_or_tuple(xkids[xi])
 end
 
-# TODO: This should be reworked to be more specific, in particular K"parens" is maybe not
-# correct (found in e.g. `function(x * b)\n\nend`).
-function is_longform_anon_function(node::Node)
-    is_leaf(node) && return false
-    kind(node) === K"function" || return false
-    kids = verified_kids(node)
-    kw = findfirst(x -> kind(x) === K"function", kids)
-    @assert kw !== nothing
-    sig = findnext(x -> !JuliaSyntax.is_whitespace(x), kids, kw + 1)::Int
-    sigkid = kids[sig]
-    maybe_tuple = unwrap_to_call_or_tuple(sigkid)
-    if maybe_tuple === nothing
-        return false
-    else
-        return kind(maybe_tuple) in KSet"tuple parens"
-    end
-end
-
-function is_longform_functor(node::Node)
-    is_leaf(node) && return false
-    kind(node) === K"function" || return false
-    kids = verified_kids(node)
-    kw = findfirst(x -> kind(x) === K"function", kids)
-    @assert kw !== nothing
-    calli = findnext(x -> !JuliaSyntax.is_whitespace(x), kids, kw + 1)::Int
-    call = kids[calli]
-    if !is_leaf(call) && kind(call) == K"call" &&
-            kind(first(verified_kids(call))) === K"parens"
-        return true
-    end
-    return false
-end
-
 # Just like `JuliaSyntax.is_infix_op_call`, but also check that the node is K"call" or
 # K"dotcall"
 function is_infix_op_call(node::Node)

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -1121,10 +1121,6 @@ function spaces_around_keywords(ctx::Context, node::Node)
     if !(kind(node) in keyword_set)
         return nothing
     end
-    if is_longform_anon_function(node)
-        # TODO: `function(` should have no space, handled elsewhere
-        return nothing
-    end
     kids = verified_kids(node)
     kids′ = kids
     any_changes = false
@@ -3187,7 +3183,7 @@ function remove_trailing_semicolon(ctx::Context, node::Node)
     pos = position(ctx.fmt_io)
     kids = verified_kids(node)
     kids′ = kids
-    block_predicate = function(x)
+    block_predicate = function (x)
         return kind(x) === K"block" && !JuliaSyntax.has_flags(x, JuliaSyntax.PARENS_FLAG)
     end
     block_idx = findfirst(block_predicate, kids′)
@@ -3296,7 +3292,7 @@ function has_return(node::Node)
     elseif kind(node) in KSet"try if elseif"
         # Look for the initial try/if block and then for
         # catch/else/finally (for try) or elseif/else (for if).
-        pred = function(x)
+        pred = function (x)
             return !is_leaf(x) && kind(x) in KSet"catch else finally elseif block"
         end
         idx = findfirst(pred, kids)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -824,9 +824,8 @@ end
         # Functors
         @test format_string("function$(sp)(a::A)(b)\nx\nend") ==
             "function (a::A)(b)\n    return x\nend"
-        # TODO: Spaces after function keyword isn't removed.
         @test format_string("function$(sp)(a * b)\nreturn\nend") ==
-            "function$(sp)(a * b)\n    return\nend"
+            "function (a * b)\n    return\nend"
         # https://github.com/fredrikekre/Runic.jl/issues/109
         @test format_string("function$(sp)(::Type{T})(::Int) where {T}\n$(sp)return T\n$(sp)end") ==
             "function (::Type{T})(::Int) where {T}\n    return T\nend"
@@ -865,7 +864,7 @@ end
             # Blocklike RHS
             for thing in (
                     "if c\n    x\nend", "try\n    x\ncatch\n    y\nend",
-                    "let c = 1\n    c\nend", "function()\n    return x\nend",
+                    "let c = 1\n    c\nend", "function ()\n    return x\nend",
                     "\"\"\"\nfoo\n\"\"\"", "r\"\"\"\nfoo\n\"\"\"",
                     "```\nfoo\n```", "r```\nfoo\n```", "```\nfoo\n```x",
                 )
@@ -1179,7 +1178,7 @@ end
         @test format_string("let a = 1 # a\nx$(d)end") == "let a = 1 # a\n    x\nend"
         # function-end
         @test format_string("function f()$(d)x$(d)end") == "function f()\n    return x\nend"
-        @test format_string("function()$(d)x$(d)end") == "function()\n    return x\nend"
+        @test format_string("function()$(d)x$(d)end") == "function ()\n    return x\nend"
         @test format_string("function ()$(d)x$(d)end") == "function ()\n    return x\nend"
         @test format_string("function f end") == "function f end"
         # macro-end


### PR DESCRIPTION
Fix a bug that caused "single space after keyword" to not apply after the `function` keyword in non-standard function definitions.