### PR TITLE
Fix multiple spaces after `let`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased changes
 ### Changed
  - Fix a bug that caused "single space after keyword" to not apply after the `function`
-   keyword in non-standard function definitions. ([#113])
+   keyword in non-standard function definitions ([#113]). This bug is classified as a
+   [spec-bug] and the fix will result in diffs like the following:
+   ```diff
+   -function()
+   +function ()
+        # ...
+    end
+   ```
+ - Fix a bug that caused "single space after keyword" to not apply after `let` ([#117]).
+   This bug is classified as a [spec-bug] and the fix will result in diffs like the
+   following when `let` is followed by multiple spaces in the source:
+   ```diff
+   -let  a = 1
+   +let a = 1
+        a
+    end
+   ```
  - Fix a bug that caused multiline variable blocks in `let` to not indent correctly ([#97],
    [#116]). This bug is classified as a [spec-bug] and the fix will result in diffs like the
-   following:
+   following whenever multiline variable blocks exist in the source:
    ```diff
     let a = 1,
    -    b = 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -552,6 +552,8 @@ end
         @test format_string("function f()\n    return$(sp)\nend") == "function f()\n    return\nend"
         @test format_string("module$(sp)A\nend") == "module A\nend"
         @test format_string("module$(sp)(A)\nend") == "module (A)\nend"
+        @test format_string("let$(sp)x = 1\nend") == "let x = 1\nend"
+        @test format_string("let$(sp)\nend") == "let\nend"
         for word in ("local", "global"), rhs in ("a", "a, b", "a = 1", "a, b = 1, 2")
             word == "const" && rhs in ("a", "a, b") && continue
             @test format_string("$(word)$(sp)$(rhs)") == "$(word) $(rhs)"


### PR DESCRIPTION
This patch ensures that a single space is used also after `let` like other keywords.