### PR TITLE
Support range formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+ - New command line option `--lines=a:b` for limiting formatting to lines `a` to `b`.
+   `--lines` can be repeated to specify multiple ranges ([#114], [#120]).
+
 ## [v1.1.0] - 2024-12-04
 ### Changed
  - Fix a bug that caused "single space after keyword" to not apply after the `function`

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -10,6 +10,13 @@ struct AssertionError <: RunicException
     msg::String
 end
 
+# Thrown from internal code when invalid CLI arguments can not be validated directly in
+# `Runic.main`: `throw(MainError("message"))` from internal code is like calling
+# `panic("message")` in `Runic.main`.
+struct MainError <: RunicException
+    msg::String
+end
+
 function Base.showerror(io::IO, err::AssertionError)
     print(
         io,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1541,6 +1541,52 @@ end
     end
 end
 
+# TODO: Support lines in format_string and format_file
+function format_lines(str, lines)
+    line_ranges = lines isa UnitRange ? [lines] : lines
+    ctx = Runic.Context(str; filemode = false, line_ranges = line_ranges)
+    Runic.format_tree!(ctx)
+    return String(take!(ctx.fmt_io))
+end
+
+@testset "--lines" begin
+    str = """
+    function f(a,b)
+        return a+b
+     end
+    """
+    @test format_lines(str, 1:1) == """
+        function f(a, b)
+            return a+b
+         end
+        """
+    @test format_lines(str, 2:2) == """
+        function f(a,b)
+            return a + b
+         end
+        """
+    @test format_lines(str, 3:3) == """
+        function f(a,b)
+            return a+b
+        end
+        """
+    @test format_lines(str, [1:1, 3:3]) == """
+        function f(a, b)
+            return a+b
+        end
+        """
+    @test format_lines(str, [1:1, 2:2, 3:3]) == """
+        function f(a, b)
+            return a + b
+        end
+        """
+    @test format_lines(str, [1:2]) == """
+        function f(a, b)
+            return a + b
+         end
+        """
+end
+
 module RunicMain1
     using Test: @testset
     using Runic: main


### PR DESCRIPTION
This patch implements the `--lines=a:b` command line argument for
limiting the formatting to the line range `a:b`. Multiple ranges are
supported. Close #114.

Examples:
```
$ cat main.jl
function f(a,b,c,d)
  a  +  b  +  c  +  d
end

$ ./bin/runic --lines=1:1 main.jl
function f(a, b, c, d)
  a  +  b  +  c  +  d
end

$ ./bin/runic --lines=2:2 main.jl
function f(a,b,c,d)
    return a + b + c + d
end
```
