### PR TITLE
Fix formatting of negative floating point literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+ - Fix formatting of floating point literals that use `−` (Unicode U+2212) instead of the
+   typically used `-` (ASCII/Unicode U+002D). The parser treats them as synonyms but the
+   former triggered an assertion error in Runic while formatting. After this change Runic
+   will normalize to `-` when formatting ([#137], [#138]).
+
 ## [v1.4.2] - 2025-02-18
 ### Fixed
  - Add missing documentation of `--lines` to the `--help` output ([#136]).
@@ -122,6 +129,7 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [v1.3.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.3.0
 [v1.4.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.0
 [v1.4.1]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.1
+[v1.4.2]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.2
 [#97]: https://github.com/fredrikekre/Runic.jl/issues/97
 [#108]: https://github.com/fredrikekre/Runic.jl/issues/108
 [#109]: https://github.com/fredrikekre/Runic.jl/issues/109
@@ -142,3 +150,5 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#132]: https://github.com/fredrikekre/Runic.jl/issues/132
 [#133]: https://github.com/fredrikekre/Runic.jl/issues/133
 [#136]: https://github.com/fredrikekre/Runic.jl/issues/136
+[#137]: https://github.com/fredrikekre/Runic.jl/issues/137
+[#138]: https://github.com/fredrikekre/Runic.jl/issues/138

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,11 @@ end
             end
         end
     end
+    # Issue #137: '−' (Unicode U+2212) is a synonym in the parser to the normally used
+    # '-' (ASCII/Unicode U+002D)
+    @test format_string("\u22121.0") == "-1.0"
+    @test format_string("1.0e\u22121") == "1.0e-1"
+    @test format_string("\u22121.0e\u22121") == "-1.0e-1"
 end
 
 @testset "whitespace between operators" begin


### PR DESCRIPTION
Fix formatting of floating point literals that use `−` (Unicode U+2212)
instead of the typically used `-` (ASCII/Unicode U+002D). The parser
treats them as synonyms but the former triggered an assertion error in
Runic while formatting. After this change Runic will normalize to `-`
when formatting. Fixes #137.
