### PR TITLE
ci: skip ci tests for commits that change only markdown files

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -7,6 +7,8 @@ on:
       - 'release-'
     tags:
       - '*'
+    paths-ignore:
+      - '**/*.md'
   pull_request:
 
 jobs:


### PR DESCRIPTION
### Change Summary
Currently, the `Test` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`bce2590`](https://github.com/fredrikekre/Runic.jl/commit/bce2590aaef765327e59c14a666bcdc986c8c857) changed these files: `TODO.md` and, when pushed, triggered [this](https://github.com/fredrikekre/Runic.jl/actions/runs/10267990691) workflow run, which ran for ~8 CPU minutes. With the proposed changes, these 8 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 6 examples over the last few months; a lower estimate for the accumulated gain is **1 CPU hour**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit bce2590](https://github.com/fredrikekre/Runic.jl/commit/bce2590) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/10267990691)
[commit 2c455a0](https://github.com/fredrikekre/Runic.jl/commit/2c455a0) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/10382409996)
[commit fa78ba6](https://github.com/fredrikekre/Runic.jl/commit/fa78ba6) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/10317998217)
[commit 73ab2ae](https://github.com/fredrikekre/Runic.jl/commit/73ab2ae) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/10354179911)
[commit 582cc96](https://github.com/fredrikekre/Runic.jl/commit/582cc96) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/11798093812)
[commit ad205bc](https://github.com/fredrikekre/Runic.jl/commit/ad205bc) => [run url](https://github.com/fredrikekre/Runic.jl/actions/runs/11801005415)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch