### PR TITLE
No trailing comma after generator in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.4] - 2025-07-24
+### Fixed
+ - Fix another edgecase where adding a trailing comma after the last item in a list results
+   in invalid code. ([#151], [#152]).
+
 ## [v1.4.3] - 2025-02-28
 ### Fixed
  - Fix formatting of floating point literals that use `−` (Unicode U+2212) instead of the

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -340,6 +340,9 @@ function spaces_in_listlike(ctx::Context, node::Node)
     allow_trailing_comma = multiline
     if kind(node) in KSet"call dotcall macrocall"
         require_trailing_comma = false
+    elseif n_items > 0 && kind(kids[last_item_idx::Int]) === K"generator"
+        # https://github.com/fredrikekre/Runic.jl/issues/151
+        require_trailing_comma = false
     elseif implicit_tuple
         # Trailing commas in implicit tuples in the LHS of an assignment, e.g. `x, = 1, 2`,
         # is required for single item tuples and allowed for multiple items (to allow e.g.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,6 +447,8 @@ end
     # Edge case with comment and no items
     @test format_string("[# a\n]") == "[# a\n]"
     @test format_string("[ # a\n]") == "[ # a\n]"
+    # https://github.com/fredrikekre/Runic.jl/issues/151
+    @test format_string("(\n    a, b for b in B\n)") == "(\n    a, b for b in B\n)"
 end
 
 @testset "whitespace in let" begin


### PR DESCRIPTION
This fix another edgecase where adding a trailing comma after the last item (a generator) in a list results in invalid code. Fixes #151.