### PR TITLE
Remove range format markers when using --lines and --diff together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.5] - 2025-07-24
+### Fixed
+ - Fix `--diff` output in combination with `--lines`. Previously the internal makers used to
+   mark the lines to be formatted would show up in the diff output. ([#154]).
+
 ## [v1.4.4] - 2025-07-24
 ### Fixed
  - Fix another edgecase where adding a trailing comma after the last item in a list results

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Runic"
 uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
-version = "1.4.4"
+version = "1.4.5"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -543,6 +543,16 @@ function maintests(f::R) where {R}
         rc, fd1, fd2 = runic(["--lines=3:4", "."])
         @test rc == 1 && isempty(fd1)
         @test occursin("option `--lines` can not be used together with multiple input files", fd2)
+        # --diff and --lines: no comment markers in diff output
+        if Sys.which("git") !== nothing
+            rc, fd1, fd2 = runic(["--lines=1:1", "--diff"], src)
+            @test rc == 0
+            @test fd1 == "function f(a, b)\n    return a+b\n end\n"
+            @test occursin("-function f(a,b)", fd2)
+            @test occursin("+function f(a, b)", fd2)
+            @test !occursin(Runic.RANGE_FORMATTING_BEGIN, fd2)
+            @test !occursin(Runic.RANGE_FORMATTING_END, fd2)
+        end
     end
 
     return


### PR DESCRIPTION
cc @aviatesk