### PR TITLE
Allow trailing newline to count as a new line in --lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.6] - 2025-07-26
+### Fixed
+ - Relax `--lines` input checking to allow using `length(lines) + 1` for the end or the
+   range. This is because some tooling considers a trailing newline to start a new (empty)
+   line as opposed to just ending the previous line.
+
 ## [v1.4.5] - 2025-07-24
 ### Fixed
  - Fix `--diff` output in combination with `--lines`. Previously the internal makers used to

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Runic"
 uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
-version = "1.4.5"
+version = "1.4.6"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -160,6 +160,14 @@ function add_line_range_markers(str, line_ranges)
     sort!(line_ranges, rev = true)
     for r in line_ranges
         a, b = extrema(r)
+        # Some tooling considers a trailing \n to start a new line (as opposed to just
+        # ending the previous line) so let's allow that by clamping b.
+        if endswith(lines[end], "\n") && b == length(lines) + 1
+            if a == length(lines) + 1
+                continue
+            end
+            b = length(lines)
+        end
         if a < 1 || b > length(lines)
             throw(MainError("`--lines` range out of bounds"))
         end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -537,7 +537,7 @@ function maintests(f::R) where {R}
         rc, fd1, fd2 = runic(["--lines=0:1"], src)
         @test rc == 1 && isempty(fd1)
         @test occursin("`--lines` range out of bounds", fd2)
-        rc, fd1, fd2 = runic(["--lines=3:4"], src)
+        rc, fd1, fd2 = runic(["--lines=3:5"], src)
         @test rc == 1 && isempty(fd1)
         @test occursin("`--lines` range out of bounds", fd2)
         rc, fd1, fd2 = runic(["--lines=3:4", "."])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1592,6 +1592,13 @@ end
             return a + b
          end
         """
+    @test format_lines(str, [2:4]) == """
+        function f(a,b)
+            return a + b
+        end
+        """
+    @test format_lines(str, [4:4]) == str
+    @test_throws Runic.MainError format_lines("1+1", [1:2])
 end
 
 module RunicMain1


### PR DESCRIPTION
Some tooling considers a trailing newline to start a new (empty) line as opposed to just ending the previous line. This patch relaxes the input check of line ranges to allow this.

CC @aviatesk