### PR TITLE
New command line argument `--stdin-filename=<filename>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.0] - 2025-07-26
+### Added
+ - New command line argument `--stdin-filename=<filename>` which allows attaching a filename
+   to stdin input. This is used for error messages ([#157]).
+
 ## [v1.4.6] - 2025-07-26
 ### Fixed
  - Relax `--lines` input checking to allow using `length(lines) + 1` for the end or the
@@ -147,6 +152,10 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [v1.4.1]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.1
 [v1.4.2]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.2
 [v1.4.3]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.3
+[v1.4.4]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.4
+[v1.4.5]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.5
+[v1.4.6]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.6
+[v1.5.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.5.0
 [#97]: https://github.com/fredrikekre/Runic.jl/issues/97
 [#108]: https://github.com/fredrikekre/Runic.jl/issues/108
 [#109]: https://github.com/fredrikekre/Runic.jl/issues/109
@@ -169,3 +178,7 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#136]: https://github.com/fredrikekre/Runic.jl/issues/136
 [#137]: https://github.com/fredrikekre/Runic.jl/issues/137
 [#138]: https://github.com/fredrikekre/Runic.jl/issues/138
+[#151]: https://github.com/fredrikekre/Runic.jl/issues/151
+[#152]: https://github.com/fredrikekre/Runic.jl/issues/152
+[#154]: https://github.com/fredrikekre/Runic.jl/issues/154
+[#157]: https://github.com/fredrikekre/Runic.jl/issues/157

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Runic"
 uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
-version = "1.4.6"
+version = "1.5.0"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/src/main.jl
+++ b/src/main.jl
@@ -147,6 +147,9 @@ function print_help()
                    File to write formatted output to. If no output is given, or if the file
                    is `-`, output is written to stdout.
 
+               --stdin-filename=<filename>
+                   Assumed filename when formatting from stdin. Used for error messages.
+
                -v, --verbose
                    Enable verbose output.
 
@@ -218,6 +221,7 @@ function main(argv)
     # Default values
     inputfiles = String[]
     outputfile = ""
+    stdin_filename = "stdin"
     quiet = false
     verbose = false
     debug = false
@@ -256,6 +260,8 @@ function main(argv)
             if insert_line_range(line_ranges, m.captures[1]::SubString) != 0
                 return errno
             end
+        elseif (m = match(r"^--stdin-filename=(.+)$", x); m !== nothing)
+            stdin_filename = String(m.captures[1]::SubString)
         elseif x == "-o"
             if length(argv) < 1
                 return panic("expected output file argument after `-o`")
@@ -406,7 +412,7 @@ function main(argv)
         end
 
         # Call the library to format the text
-        inputfile_pretty = inputfile == "-" ? "stdin" : inputfile
+        inputfile_pretty = inputfile == "-" ? stdin_filename : inputfile
         ctx = try
             ctx′ = Context(
                 sourcetext; quiet, verbose, debug, diff, check, line_ranges,

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -56,6 +56,18 @@ function maintests(f::R) where {R}
         @test isempty(fd2)
     end
 
+    # runic --stdin-filename <stdin >stdout
+    let (rc, fd1, fd2) = runic(["--stdin-filename=/foo/bar/baz.jl"], "a+")
+        @test rc == 1
+        @test isempty(fd1)
+        @test occursin("failed to parse input from /foo/bar/baz.jl", fd2)
+    end
+    let (rc, fd1, fd2) = runic(String[], "a+")
+        @test rc == 1
+        @test isempty(fd1)
+        @test occursin("failed to parse input from stdin", fd2)
+    end
+
     # runic --output=out.jl <stdin
     cdtmp() do
         f_out = "out.jl"


### PR DESCRIPTION
This allows assuming a filename when formatting/checking data from stdin. This is used for error messages etc.