### PR TITLE
Update README.md with instructions for Zed

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,26 @@ auto-format = false
 formatter = { command = "julia" , args = ["--project=@runic", "--startup-file=no", "-e", "using Runic; exit(Runic.main(ARGS))"] }
 ```
 
+#### Zed
+
+Runic can be used as a formatter in [Zed](https://zed.dev/). You can configure Runic as a 
+local formatter by adding the following entry to your `settings.json`. This assumes Runic 
+is installed in the `@runic` shared project as suggested in the [Installation](#installation) 
+section above. Adjust the `--project` flag if you installed Runic somewhere else.
+
+```json
+"languages": {
+  "Julia": {
+    "formatter": {
+      "external": {
+        "command": "julia",
+        "arguments": ["--project=@runic", "--startup-file=no", "-e", "using Runic; exit(Runic.main(ARGS))"]
+      }
+    }
+  }
+}
+```
+
 ### Git integration
 
 The [`git-runic`](https://github.com/fredrikekre/Runic.jl/blob/master/bin/git-runic)


### PR DESCRIPTION
The [Zed editor](https://zed.dev/) is quite popular in some circles (it's fast). This PR adds instructions for using Runic as a formatter.