### PR TITLE
Update README.md for Neovim/conform

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,19 +212,10 @@ Runic can be used as a formatter in [Neovim](https://neovim.io/) using
 [conform.nvim](https://github.com/stevearc/conform.nvim). Refer to the conform.nvim
 repository for installation and setup instructions.
 
-Runic is not (yet) available directly in conform so the following configuration needs
-to be passed to the setup function. This assumes Runic is installed in the `@runic` shared
-project as suggested in the [Installation](#installation) section above. Adjust the
-`--project` flag if you installed Runic somewhere else.
+Runic is available directly in conform and can be configured as follows. This assumes Runic is installed in the `@runic` shared project as suggested in the [Installation](#installation) section above.
 
 ```lua
 require("conform").setup({
-    formatters = {
-        runic = {
-            command = "julia",
-            args = {"--project=@runic", "--startup-file=no", "-e", "using Runic; exit(Runic.main(ARGS))"},
-        },
-    },
     formatters_by_ft = {
         julia = {"runic"},
     },

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Runic can be used as a formatter in [Neovim](https://neovim.io/) using
 [conform.nvim](https://github.com/stevearc/conform.nvim). Refer to the conform.nvim
 repository for installation and setup instructions.
 
-Runic is available directly in conform and can be configured as follows. This assumes Runic is installed in the `@runic` shared project as suggested in the [Installation](#installation) section above.
+Runic is available directly in conform and can be configured as follows. This assumes Runic is installed in the `@runic` shared project and the `runic` CLI script is installed as suggested in the [Installation](#installation) section above.
 
 ```lua
 require("conform").setup({


### PR DESCRIPTION
This PR updates the README.md to reflect direct availability of Runic in conform and simplify configuration instructions.

I had some issues with using the current suggested conform config where the `--lines=x:y` argument would be sent to julia instead of runic. Removing the custom formatting setup seems to fix the issue.

from conform.log: 
```
2025-09-06 15:24:36[ERROR] Formatter 'runic' error: ERROR: unknown option `--lines=423:427`
```