### PR TITLE
Ignore formatting of hex literals with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.1] - 2025-09-24
+### Fixed
+ - Ignore formatting of hex literals with underscores (same as for floats and integers)
+   ([#169], [#170]).
+
 ## [v1.5.0] - 2025-07-26
 ### Added
  - New command line argument `--stdin-filename=<filename>` which allows attaching a filename
@@ -156,6 +161,7 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [v1.4.5]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.5
 [v1.4.6]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.4.6
 [v1.5.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.5.0
+[v1.5.1]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.5.1
 [#97]: https://github.com/fredrikekre/Runic.jl/issues/97
 [#108]: https://github.com/fredrikekre/Runic.jl/issues/108
 [#109]: https://github.com/fredrikekre/Runic.jl/issues/109
@@ -182,3 +188,5 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#152]: https://github.com/fredrikekre/Runic.jl/issues/152
 [#154]: https://github.com/fredrikekre/Runic.jl/issues/154
 [#157]: https://github.com/fredrikekre/Runic.jl/issues/157
+[#169]: https://github.com/fredrikekre/Runic.jl/issues/169
+[#170]: https://github.com/fredrikekre/Runic.jl/issues/170

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Runic"
 uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -64,6 +64,10 @@ function format_hex_literals(ctx::Context, node::Node)
     # Insert leading zeros
     i = findfirst(x -> x > spn, target_spans)::Int
     bytes = read_bytes(ctx, node)
+    # Ignore literals with underscores for now (same as for floats)
+    if findfirst(==('_' % UInt8), bytes) !== nothing
+        return nothing
+    end
     while length(bytes) < target_spans[i]
         insert!(bytes, 3, '0')
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,9 @@ end
         @test typeof(c) == typeof(d)
         @test format_string(a) == b
     end
+    # Ignore literals with underscores (https://github.com/fredrikekre/Runic.jl/issues/169)
+    @test format_string("0xaa_aa_aa_aa") == "0xaa_aa_aa_aa"
+    @test format_string("0xaa_aa") == ("0xaa_aa")
 end
 
 @testset "Floating point literals" begin


### PR DESCRIPTION
Ohter number literals, like floats and integers, with underscores are already ignored (for now). Fixes #169.