### PR TITLE
Update version of pre-commit hook to v2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,13 +513,13 @@ Runic before each commit:
 ```yaml
 repos:
   - repo: https://github.com/fredrikekre/runic-pre-commit
-    rev: v1.0.0
+    rev: v2.0.1
     hooks:
       - id: runic
 ```
 
 See [`fredrikekre/runic-pre-commit`](https://github.com/fredrikekre/runic-pre-commit) for
-details.
+the latest version and more details.
 
 If you don't want to use `pre-commit` you can also use a plain git hook. Here is an example
 hook (`.git/hooks/pre-commit`):


### PR DESCRIPTION
This is the version using language julia support.

https://github.com/fredrikekre/runic-pre-commit/pull/2
https://github.com/pre-commit/pre-commit/releases/tag/v4.1.0

Since that has been out for a year it is probably fine to recommend it by default.

It also works fine to update the hook rev with:
```
pre-commit autoupdate
```