### PR TITLE
Formatting of Julia code in docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.0] - TBD
+### Added
+ - New opt-in flag `--docstrings` (and corresponding `docstrings::Bool` keyword argument for
+   `format_string` / `format_file`) that enables formatting of Julia code inside docstrings.
+   Fenced ```` ```julia ````, ```` ```julia-repl ````, and ```` ```jldoctest ```` blocks
+   have their contents run through Runic. All indented markdown code blocks (including
+   leading method signatures) are also formatted (and thus assumed to be Julia code blocks).
+   ([#174], [#196])
+
 ## [v1.6.1] - 2026-04-16
 ### Fixed
  - Fix indentation of `function @main(args)` bodies ([#175], [#193]).
@@ -215,8 +224,10 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#169]: https://github.com/fredrikekre/Runic.jl/issues/169
 [#170]: https://github.com/fredrikekre/Runic.jl/issues/170
 [#171]: https://github.com/fredrikekre/Runic.jl/issues/171
+[#174]: https://github.com/fredrikekre/Runic.jl/issues/174
 [#175]: https://github.com/fredrikekre/Runic.jl/issues/175
 [#186]: https://github.com/fredrikekre/Runic.jl/issues/186
 [#187]: https://github.com/fredrikekre/Runic.jl/issues/187
 [#193]: https://github.com/fredrikekre/Runic.jl/pull/193
 [#194]: https://github.com/fredrikekre/Runic.jl/pull/194
+[#196]: https://github.com/fredrikekre/Runic.jl/pull/196

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,12 @@ version = "1.6.1"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
-[apps]
-runic = {}
-
 [compat]
 JuliaSyntax = "1"
 Preferences = "1"
 julia = "1.10"
+
+[apps.runic]
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -137,6 +137,7 @@ mutable struct Context
     check::Bool
     diff::Bool
     filemode::Bool
+    docstrings::Bool
     filename::String
     line_ranges::Vector{UnitRange{Int}}
     # Global state
@@ -248,6 +249,7 @@ end
 function Context(
         src_str::String; assert::Bool = true, debug::Bool = false, verbose::Bool = debug,
         diff::Bool = false, check::Bool = false, quiet::Bool = false, filemode::Bool = true,
+        docstrings::Bool = false,
         line_ranges::Vector{UnitRange{Int}} = UnitRange{Int}[], filename::String = "-",
     )
     if !isempty(line_ranges)
@@ -288,7 +290,7 @@ function Context(
     format_on = true
     return Context(
         src_str, src_tree, src_io, fmt_io, fmt_tree, quiet, verbose, assert, debug, check,
-        diff, filemode, filename, line_ranges, indent_level, call_depth, format_on,
+        diff, filemode, docstrings, filename, line_ranges, indent_level, call_depth, format_on,
         prev_sibling, next_sibling, lineage_kinds, lineage_macros
     )
 end
@@ -564,6 +566,7 @@ function format_node!(ctx::Context, node::Node)::Union{Node, Nothing, NullNode}
     @return_something explicit_return(ctx, node)
     @return_something braces_around_where_rhs(ctx, node)
     @return_something indent_multiline_strings(ctx, node)
+    @return_something format_docstring(ctx, node)
     @return_something four_space_indent(ctx, node)
     @return_something spaces_in_listlike(ctx, node)
     ctx.call_depth -= 1
@@ -636,8 +639,8 @@ end
 
 Format string `str` and return the formatted string.
 """
-function format_string(str::AbstractString; filemode::Bool = false)
-    ctx = Context(str; filemode = filemode, filename = "string")
+function format_string(str::AbstractString; filemode::Bool = false, docstrings::Bool = false)
+    ctx = Context(str; filemode = filemode, docstrings = docstrings, filename = "string")
     format_tree!(ctx)
     return String(take!(ctx.fmt_io))
 end
@@ -654,7 +657,7 @@ Format file `inputfile` and write the formatted text to `outputfile`.
 Setting the keyword argument `inplace = true` is required if `inputfile` and `outputfile`
 are the same file.
 """
-function format_file(inputfile::AbstractString, outputfile::AbstractString = inputfile; inplace::Bool = false)
+function format_file(inputfile::AbstractString, outputfile::AbstractString = inputfile; inplace::Bool = false, docstrings::Bool = false)
     # Argument handling
     inputfile = normpath(abspath(String(inputfile)))
     outputfile = normpath(abspath(String(outputfile)))
@@ -663,7 +666,7 @@ function format_file(inputfile::AbstractString, outputfile::AbstractString = inp
         error("input and output must not be the same when `inplace = false`")
     end
     # Format it
-    ctx = Context(str; filename = inputfile)
+    ctx = Context(str; filename = inputfile, docstrings = docstrings)
     format_tree!(ctx)
     # Write the output but skip if it text didn't change
     changed = ctx.fmt_tree !== nothing

--- a/src/main.jl
+++ b/src/main.jl
@@ -155,6 +155,9 @@ function print_help()
 
                --version
                    Print Runic and julia version information.
+
+               --docstrings
+                   Format code blocks in docstrings embedded in source files.
         """
     )
     return
@@ -228,6 +231,7 @@ function main(argv)
     inplace = false
     diff = false
     check = false
+    docstrings = false
     fail_fast = false
     line_ranges = typeof(1:2)[]
     input_is_stdin = true
@@ -254,6 +258,8 @@ function main(argv)
             diff = true
         elseif x == "-c" || x == "--check"
             check = true
+        elseif x == "--docstrings"
+            docstrings = true
         elseif x == "-vv" || x == "--debug"
             debug = verbose = true
         elseif (m = match(r"^--lines=(.*)$", x); m !== nothing)
@@ -415,7 +421,7 @@ function main(argv)
         inputfile_pretty = inputfile == "-" ? stdin_filename : inputfile
         ctx = try
             ctx′ = Context(
-                sourcetext; quiet, verbose, debug, diff, check, line_ranges,
+                sourcetext; quiet, verbose, debug, diff, check, docstrings, line_ranges,
                 filename = inputfile_pretty,
             )
             format_tree!(ctx′)

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -3310,6 +3310,352 @@ function indent_multiline_strings(ctx::Context, node::Node)
     return any_changes ? make_node(node, kids′) : nothing
 end
 
+const re_fence_open = r"^(\h*)(`{3,})\h*([A-Za-z0-9_-]*)"
+
+is_julia_lang(lang::AbstractString) = lang in ("julia", "julia-repl", "jldoctest")
+
+function format_julia_block(block_lines::Vector{String})
+    isempty(block_lines) && return block_lines
+    code = join(block_lines)
+    # When formatting blocks we adhere to "if it parses we format it" since sometimes blocks
+    # are tagged as Julia code but may be pseudo-code for example.
+    formatted = try
+        format_string(code)
+    catch e
+        e isa JuliaSyntax.ParseError || rethrow()
+        # @error "Could not parse julia block" code e
+        return block_lines
+    end
+    return collect(eachline(IOBuffer(formatted); keep = true))
+end
+
+const JULIA_REPL_PROMPT = "julia> "
+
+# Strip the prompt, leading whitespace and output. Format the input lines and re-insert the
+# prompt and leading whitespace.
+function format_repl_block(block_lines::Vector{String})
+    nprompt = length(JULIA_REPL_PROMPT)
+    continuation = " "^nprompt
+    result = String[]
+    i = 1
+    while i <= length(block_lines)
+        line = block_lines[i]
+        if startswith(line, JULIA_REPL_PROMPT)
+            # Collect the full input chunk: strip the prompt prefix and continuations
+            input_lines = String[chop(line; head = nprompt, tail = 0)]
+            j = i + 1
+            while j <= length(block_lines)
+                next_line = block_lines[j]
+                nspaces = 0
+                for c in next_line
+                    c == ' ' ? (nspaces += 1) : break
+                end
+                if isempty(strip(next_line))
+                    push!(input_lines, "\n")
+                    j += 1
+                elseif nspaces >= nprompt
+                    push!(input_lines, chop(next_line; head = nprompt, tail = 0))
+                    j += 1
+                else
+                    break
+                end
+            end
+            code = join(input_lines)
+            # Same as `format_julia_block`: only format if the block parses; fall back
+            # to passing the original prompt/continuation lines through unchanged.
+            formatted = try
+                format_string(code)
+            catch e
+                e isa JuliaSyntax.ParseError || rethrow()
+                # @error "Could not parse julia block" code e
+                for k in i:(j - 1)
+                    push!(result, block_lines[k])
+                end
+                i = j
+                continue
+            end
+            fmt_lines = eachline(IOBuffer(formatted); keep = true)
+            first = true
+            for fl in fmt_lines
+                if isempty(strip(fl))
+                    push!(result, "\n")
+                elseif first
+                    push!(result, JULIA_REPL_PROMPT * fl)
+                    first = false
+                else
+                    push!(result, continuation * fl)
+                end
+            end
+            i = j
+        else
+            push!(result, line)
+            i += 1
+        end
+    end
+    return result
+end
+
+# Dispatch to REPL formatter or regular formatter based on the code blocks language
+function format_code_block(block_lines::Vector{String}, lang::String)
+    if lang == "julia-repl"
+        return format_repl_block(block_lines)
+    elseif lang == "jldoctest"
+        if any(l -> startswith(l, JULIA_REPL_PROMPT), block_lines)
+            return format_repl_block(block_lines)
+        else
+            return format_julia_block(block_lines)
+        end
+    else
+        return format_julia_block(block_lines)
+    end
+end
+
+# Identify julia source code blocks (``` blocks four-space-indent blocks),
+# collect the lines, format the text and re-insert
+function format_markdown(s::String)
+    lines = collect(eachline(IOBuffer(s); keep = true))
+    isempty(lines) && return s
+    # Indented code blocks (CommonMark "indented" style) are handled like implicit
+    # fences: opener is blank-line-or-start-of-docstring followed by a non-blank line
+    # with >= 4 leading spaces; content = consecutive non-blank 4-space-indented lines;
+    # closer = blank line or end-of-docstring. Same strip / format / re-indent pipeline
+    # as ```julia fences, reused via format_julia_block.
+    base_indent = "    "
+    nbase_indent = ncodeunits(base_indent)
+    result = String[]
+    i = 1
+    # True at start-of-content and just after any blank line. Indented code blocks can
+    # only begin at block boundaries (CommonMark rule: must be preceded by a blank line).
+    at_boundary = true
+    while i <= length(lines)
+        line = lines[i]
+        m = match(re_fence_open, line)
+        if m !== nothing
+            indent = String(m.captures[1]::AbstractString)
+            ticks = String(m.captures[2]::AbstractString)
+            lang = String(m.captures[3]::AbstractString)
+            nticks = length(ticks)
+            re_close = Regex("^$(escape_string(indent))`{$(nticks)}\\h*\$")
+            close_i = findnext(l -> occursin(re_close, l), lines, i + 1)
+            if close_i === nothing
+                # Unclosed fence: everything from here to end of string is inside this
+                # (unclosed) block, so there are no further formattable fences.
+                append!(result, @view lines[i:end])
+                break
+            end
+            block_lines = lines[(i + 1):(close_i - 1)]
+            # Non-Julia fence: copy through unchanged
+            if !is_julia_lang(lang)
+                append!(result, @view lines[i:close_i])
+                i = close_i + 1
+                at_boundary = false
+                continue
+            end
+            nindent = ncodeunits(indent)
+            # Require non-empty block lines to have >= nindent leading spaces (empty lines
+            # are exempt). Strip nindent spaces before formatting so format_string sees
+            # toplevel code, then restore using the original count after formatting
+            stripped_block = String[]
+            valid_indent = true
+            for l in block_lines
+                if isempty(strip(l))
+                    push!(stripped_block, l)
+                elseif nindent == 0 || startswith(l, indent)
+                    push!(stripped_block, nindent == 0 ? l : l[(nindent + 1):end])
+                else
+                    valid_indent = false
+                    break
+                end
+            end
+            if !valid_indent
+                append!(result, @view lines[i:close_i])
+                i = close_i + 1
+                at_boundary = false
+                continue
+            end
+            formatted_stripped = format_code_block(stripped_block, lang)
+            formatted_block = nindent == 0 ? formatted_stripped :
+                [isempty(strip(l)) ? l : indent * l for l in formatted_stripped]
+            push!(result, line)
+            append!(result, formatted_block)
+            push!(result, lines[close_i])
+            i = close_i + 1
+            at_boundary = false
+        elseif at_boundary && startswith(line, base_indent) && !all(isspace, line)
+            # Indented code block. Blank lines inside the block are allowed (same as
+            # inside ```-fences): skip them during the scan and only confirm `end_idx`
+            # when another indented non-blank line is found. Terminator = an unindented
+            # non-blank line or EOF. Any trailing blank lines after the last indented
+            # line are *not* included in the block.
+            end_idx = i
+            k = i
+            while k + 1 <= length(lines)
+                next_line = lines[k + 1]
+                if all(isspace, next_line)
+                    k += 1
+                elseif startswith(next_line, base_indent)
+                    k += 1
+                    end_idx = k
+                else
+                    break
+                end
+            end
+            # Strip the indent; normalize blank lines to "\n" (explicit trailing spaces
+            # on blank lines are not meaningful and chop would swallow the '\n').
+            stripped = String[
+                isempty(strip(l)) ? "\n" : chop(l; head = nbase_indent, tail = 0)
+                    for l in lines[i:end_idx]
+            ]
+            formatted = format_julia_block(stripped)
+            if formatted == stripped
+                # parse failed or already idempotent — pass through unchanged
+                append!(result, @view lines[i:end_idx])
+            else
+                for l in formatted
+                    push!(result, isempty(strip(l)) ? l : base_indent * l)
+                end
+            end
+            i = end_idx + 1
+            at_boundary = false
+        else
+            push!(result, line)
+            at_boundary = all(isspace, line)
+            i += 1
+        end
+    end
+    return join(result)
+end
+
+# Extract the string content from a triple string node, pass to format_markdown,
+# re-interpret lines as a triple string node.
+function format_docstring_string(ctx::Context, node::Node)
+    @assert is_triple_string(node)
+    triplekind = K"\"\"\""
+
+    pos = position(ctx.fmt_io)
+    str_kids = verified_kids(node)
+    open_idx = findfirst(x -> kind(x) === triplekind, str_kids)::Int
+    close_idx = findnext(x -> kind(x) === triplekind, str_kids, open_idx + 1)::Int
+
+    # Bail out if the docstring contains anything other than plain string/whitespace
+    # between the triple-quote delimiters (e.g. $-interpolation introduces K"$" and
+    # K"Identifier" / K"parens" kids).
+    # TODO: Support interpolation by collecting bytes from all non-indent kids (skip
+    #       K"Whitespace" + leading trivia K"String" only), formatting as text, then
+    #       re-parsing the formatted output as `"""..."""` and grafting the resulting kids.
+    for i in (open_idx + 1):(close_idx - 1)
+        k = kind(str_kids[i])
+        k === K"String" || k === K"Whitespace" || return nothing
+    end
+
+    # Collect indent whitespace (first K"Whitespace" kid) and content bytes
+    indent_ws_bytes = UInt8[]
+    content_bytes = UInt8[]
+    for kid in str_kids
+        # The `\n` immediately after the opening `"""` is parsed as a trivia-flagged
+        # `K"String"` kid (rather than as content) when content starts on the next line.
+        # Skip it here — that leading newline is part of the delimiter convention, not
+        # the docstring content.
+        if kind(kid) === K"String" && !JuliaSyntax.is_trivia(kid)
+            append!(content_bytes, read_bytes(ctx, kid))
+        elseif kind(kid) === K"Whitespace" && isempty(indent_ws_bytes)
+            # All K"Whitespace" kids of a triple-quoted string contain the same bytes —
+            # the common leading indent stripped by the parser (same size on every
+            # non-empty line). Record the first one we see and skip the rest. A zero-
+            # length `K"Whitespace"` kid is impossible (the parser never emits zero-span
+            # tokens), so `isempty(indent_ws_bytes)` is a reliable "have we recorded
+            # the indent yet?" flag.
+            append!(indent_ws_bytes, read_bytes(ctx, kid))
+        end
+        accept_node!(ctx, kid)
+    end
+    @assert position(ctx.fmt_io) == pos + span(node)
+
+    # Pass the extracted string to the markdown formatter
+    content = String(content_bytes)
+    formatted = format_markdown(content)
+    seek(ctx.fmt_io, pos)
+    content == formatted && return nothing
+
+    # The opening """ may be followed by a trivia K"String" "\n" (when content starts on
+    # a new line) or directly by non-trivia content (when the first line already has
+    # content, e.g. `"""Summary.\n...\n"""`).
+    has_leading_nl = open_idx + 1 < close_idx &&
+        kind(str_kids[open_idx + 1]) === K"String" &&
+        JuliaSyntax.has_flags(str_kids[open_idx + 1], JuliaSyntax.TRIVIA_FLAG)
+    prefix_count = has_leading_nl ? 2 : 1
+    open_idx + prefix_count <= close_idx || return nothing
+
+    # Accept the fixed prefix: opening """ and optional trivia \n
+    for k in 0:(prefix_count - 1)
+        accept_node!(ctx, str_kids[open_idx + k])
+    end
+
+    # Span of the middle section: everything between the accepted prefix and close_idx
+    middle_span = sum(span(str_kids[i]) for i in (open_idx + prefix_count):(close_idx - 1); init = 0)
+
+    # Split up the formatted strings and insert the trivia newlines and leading whitespace
+    new_middle_bytes = UInt8[]
+    new_middle_kids = Node[]
+    ws_head = JuliaSyntax.SyntaxHead(K"Whitespace", JuliaSyntax.TRIVIA_FLAG)
+    str_head = JuliaSyntax.SyntaxHead(K"String", 0)
+    for line in eachline(IOBuffer(formatted); keep = true)
+        line_bytes = codeunits(line)
+        if length(line_bytes) == 1 && line_bytes[1] == UInt8('\n')
+            # Empty line should note have leading whitespace trivia
+            push!(new_middle_bytes, UInt8('\n'))
+            push!(new_middle_kids, Node(str_head, 1))
+        else
+            # Include the indent whitespace from the original source
+            if !isempty(indent_ws_bytes)
+                append!(new_middle_bytes, indent_ws_bytes)
+                push!(new_middle_kids, Node(ws_head, length(indent_ws_bytes)))
+            end
+            append!(new_middle_bytes, line_bytes)
+            push!(new_middle_kids, Node(str_head, length(line_bytes)))
+        end
+    end
+    # For an indented triple string, the parser also emits a K"Whitespace" between the
+    # final content line and the closing `"""` — representing the indent on the closing
+    # delimiter's own line. Append it so the reconstructed structure matches.
+    if !isempty(indent_ws_bytes)
+        append!(new_middle_bytes, indent_ws_bytes)
+        push!(new_middle_kids, Node(ws_head, length(indent_ws_bytes)))
+    end
+
+    # Insert the formatted bytes into the stream
+    replace_bytes!(ctx, new_middle_bytes, middle_span)
+    seek(ctx.fmt_io, pos)
+
+    # Well-formed triple-quoted strings always have the closing """ as the last kid —
+    # `"""` is balanced, and no trailing kids can follow it in a valid parse.
+    @assert close_idx == length(str_kids)
+    new_str_kids = Node[str_kids[i] for i in open_idx:(open_idx + prefix_count - 1)]
+    append!(new_str_kids, new_middle_kids)
+    push!(new_str_kids, str_kids[close_idx])
+    return make_node(node, new_str_kids)
+end
+
+# Find string literals that are docstrings (K"doc" or @doc). We only consider triple-strings
+# even though regular "..." strings can also be docstrings (but they rarely, if ever,
+# contain julia code blocks).
+function format_docstring(ctx::Context, node::Node)
+    ctx.docstrings || return nothing
+    # Only triple-quoted K"string" nodes (not cmdstring) can be docstrings
+    kind(node) === K"string" || return nothing
+    JuliaSyntax.has_flags(node, JuliaSyntax.TRIPLE_STRING_FLAG) || return nothing
+    # Must be a direct child of a doc-string context
+    isempty(ctx.lineage_kinds) && return nothing
+    parent_kind = ctx.lineage_kinds[end]
+    if parent_kind === K"doc"
+        return format_docstring_string(ctx, node)
+    elseif parent_kind === K"macrocall" && !isempty(ctx.lineage_macros) &&
+            ctx.lineage_macros[end] == "@doc"
+        return format_docstring_string(ctx, node)
+    end
+    return nothing
+end
+
 # Pattern matching for "bad" semicolons:
 #  - `\s*;\n` -> `\n`
 #  - `\s*;\s*#\n` -> `\s* \s*#\n`

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -567,6 +567,16 @@ function maintests(f::R) where {R}
         end
     end
 
+    # runic --docstrings
+    let src = "\"\"\"\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n",
+            expected = "\"\"\"\n```julia\nx = 1\n```\n\"\"\"\nfunction foo()\nend\n"
+        rc, fd1, fd2 = runic(String[], src)
+        @test rc == 0 && fd1 == src  # no change without --docstrings
+        rc, fd1, fd2 = runic(["--docstrings"], src)
+        @test rc == 0 && fd1 == expected
+        @test isempty(fd2)
+    end
+
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1646,6 +1646,213 @@ end
     @test_throws Runic.MainError format_lines("1+1", [1:2])
 end
 
+@testset "docstrings" begin
+    ds(str) = format_string(str; docstrings = true)
+
+    # Disabled by default
+    src = "\"\"\"\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test format_string(src) == src
+    @test ds(src) != src
+
+    # Plain julia block: code is formatted
+    @test ds("\"\"\"\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n") ==
+        "\"\"\"\n```julia\nx = 1\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # julia-repl block: julia> lines formatted, output untouched
+    @test ds("\"\"\"\n```julia-repl\njulia> x=1\n1\n```\n\"\"\"\nfunction foo()\nend\n") ==
+        "\"\"\"\n```julia-repl\njulia> x = 1\n1\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # jldoctest plain style
+    @test ds("\"\"\"\n```jldoctest\nx=1\ny=2\n```\n\"\"\"\nfunction foo()\nend\n") ==
+        "\"\"\"\n```jldoctest\nx = 1\ny = 2\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # jldoctest with julia> prompts
+    @test ds("\"\"\"\n```jldoctest\njulia> x=1\n1\n```\n\"\"\"\nfunction foo()\nend\n") ==
+        "\"\"\"\n```jldoctest\njulia> x = 1\n1\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # Invalid code block: left untouched
+    src_invalid = "\"\"\"\n```julia\nx = 1 +\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_invalid) == src_invalid
+
+    # Other REPL prompts treated as output (left untouched)
+    src_prompts = "\"\"\"\n```julia-repl\njulia> x=1\n1\npkg> add Foo\nshell> ls\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_prompts) == "\"\"\"\n```julia-repl\njulia> x = 1\n1\npkg> add Foo\nshell> ls\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # @doc pattern
+    @test ds("@doc \"\"\"\n```julia\nx=1\n```\n\"\"\" function foo()\nend\n") ==
+        "@doc \"\"\"\n```julia\nx = 1\n```\n\"\"\" function foo()\nend\n"
+
+    # Signature formatted when valid Julia
+    @test ds("\"\"\"\n    foo(x, y)\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n") ==
+        "\"\"\"\n    foo(x, y)\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+
+    # Signature with spacing issue is formatted
+    @test ds("\"\"\"\n    foo( x,y )\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n") ==
+        "\"\"\"\n    foo(x, y)\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+
+    # Signatures containing vect-like syntax are NOW formatted (parses → format). Users
+    # who want informal optional-arg notation can rewrite to valid forms themselves.
+    src_sig_vect = "\"\"\"\n    foo(x, [y])\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+    @test ds(src_sig_vect) == src_sig_vect  # already clean — idempotent
+    # Juxtaposition form `[x, ]y` formats by stripping the trailing comma to
+    # `[x]y` — the parse (juxtapose) is preserved. Users wanting `[x], y` can rewrite.
+    src_sig_juxta = "\"\"\"\n    render_asap([callback::Function, ]screen, N)\n\nDocs.\n\"\"\"\nfunction render_asap()\nend\n"
+    @test ds(src_sig_juxta) ==
+        "\"\"\"\n    render_asap([callback::Function]screen, N)\n\nDocs.\n\"\"\"\nfunction render_asap()\nend\n"
+
+    # `f(args) -> T` and `f(args)::T` are formatted like any other parseable Julia
+    src_sig_arrow = "\"\"\"\n    foo( x,y ) -> T\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+    @test ds(src_sig_arrow) ==
+        "\"\"\"\n    foo(x, y) -> T\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+    src_sig_rettype = "\"\"\"\n    foo( x,y )::Vector{T}\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+    @test ds(src_sig_rettype) ==
+        "\"\"\"\n    foo(x, y)::Vector{T}\n\nDocs.\n\"\"\"\nfunction foo(x, y)\nend\n"
+
+    # `where` clause now formats too
+    src_sig_where = "\"\"\"\n    foo( x::T ) where T\n\nDocs.\n\"\"\"\nfunction foo(x)\nend\n"
+    @test ds(src_sig_where) ==
+        "\"\"\"\n    foo(x::T) where {T}\n\nDocs.\n\"\"\"\nfunction foo(x)\nend\n"
+
+    # Multiple consecutive indented signatures (stacked method headers). Formatted as a
+    # single block.
+    src_multi_stacked = "\"\"\"\n    f()\n    f(x)\n\ntext\n\"\"\"\nf(x = 1) = sin(x)\n"
+    @test ds(src_multi_stacked) == src_multi_stacked
+    src_multi_mangled = "\"\"\"\n    f( )\n    f(x)\n\ntext\n\"\"\"\nf(x = 1) = sin(x)\n"
+    @test ds(src_multi_mangled) ==
+        "\"\"\"\n    f()\n    f(x)\n\ntext\n\"\"\"\nf(x = 1) = sin(x)\n"
+
+    # Multi-line signature with hanging args: continuation lines have > 4 spaces of
+    # indent. The whole block is treated as one expression.
+    src_multiline_sig = "\"\"\"\n    f(\n        x,\n        y,\n    )\n\ntext\n\"\"\"\nf(x, y) = x + y\n"
+    @test ds(src_multiline_sig) == src_multiline_sig
+    # Multi-line signature with extra whitespace needing cleanup (not idempotent)
+    src_multiline_mangled = "\"\"\"\n    f(\n        x  ,\n        y,\n    )\n\ntext\n\"\"\"\nf(x, y) = x + y\n"
+    @test ds(src_multiline_mangled) ==
+        "\"\"\"\n    f(\n        x,\n        y,\n    )\n\ntext\n\"\"\"\nf(x, y) = x + y\n"
+
+    # Stacked signatures where one is single-line and another is multi-line — the
+    # whole block is formatted as a sequence of top-level expressions.
+    src_stacked_mixed = "\"\"\"\n    f(x)\n    f(\n        x,\n        y,\n    )\n\ntext\n\"\"\"\nf(x) = x\n"
+    @test ds(src_stacked_mixed) == src_stacked_mixed
+
+    # Stacked block where one sig is ill-formed (unclosed paren): the whole block
+    # fails to parse → everything left unchanged, no partial formatting.
+    src_stacked_illformed = "\"\"\"\n    f( x )\n    f(x,\n\ntext\n\"\"\"\nf(x) = x\n"
+    @test ds(src_stacked_illformed) == src_stacked_illformed
+
+    # Multiple indented blocks separated by prose — ALL are now formatted (each
+    # blank-line-bounded indented block is treated as a code block).
+    src_multi_sig = "\"\"\"\n    sig1( x )\n\nDocs.\n\n    sig2( y )\n\nMore.\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_multi_sig) ==
+        "\"\"\"\n    sig1(x)\n\nDocs.\n\n    sig2(y)\n\nMore.\n\"\"\"\nfunction foo()\nend\n"
+
+    # Indented code block not at the start — also formatted
+    src_middle_block = "\"\"\"\nPlain docs paragraph.\n\n    x=1\n    y=2\n\nMore text.\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_middle_block) ==
+        "\"\"\"\nPlain docs paragraph.\n\n    x = 1\n    y = 2\n\nMore text.\n\"\"\"\nfunction foo()\nend\n"
+
+    # Indented block that doesn't parse as Julia (prose that looks indented) — left
+    # untouched.
+    src_indented_prose = "\"\"\"\ntext\n\n    this is prose that does not parse\n    because it has multiple words\n\nmore text\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_indented_prose) == src_indented_prose
+
+    # Indented block preceded directly by prose (no blank line) is NOT an indented
+    # code block per CommonMark — left untouched.
+    src_indented_no_blank = "\"\"\"\ntext before\n    x=1\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_indented_no_blank) == src_indented_no_blank
+
+    # Blank lines INSIDE an indented region don't terminate the block (same as inside
+    # ```-fences). Block ends only at an unindented non-blank line or EOF. A trailing
+    # blank line after the last indented line is NOT absorbed into the block.
+    src_blank_between = "\"\"\"\n    f( )\n\n    g( )\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_blank_between) ==
+        "\"\"\"\n    f()\n\n    g()\n\"\"\"\nfunction foo()\nend\n"
+
+    # Multi-statement block spanning a blank line — joined, parsed as one piece, which
+    # is the motivating case for the "blank-line-stays-inside" rule.
+    src_block_with_internal_blank = "\"\"\"\n    x=1\n\n    y = x + 1\n\ntext\n\"\"\"\nf() = nothing\n"
+    @test ds(src_block_with_internal_blank) ==
+        "\"\"\"\n    x = 1\n\n    y = x + 1\n\ntext\n\"\"\"\nf() = nothing\n"
+
+    # Fence with 4+ backticks
+    @test ds("\"\"\"\n````julia\nx=1\n````\n\"\"\"\nfunction foo()\nend\n") ==
+        "\"\"\"\n````julia\nx = 1\n````\n\"\"\"\nfunction foo()\nend\n"
+
+    # Non-matching language fences: left untouched
+    for lang in ("python", "shell", "bash", "c", "toml", "")
+        src_other = "\"\"\"\n```$(lang)\nx=1\n```\n\"\"\"\nfunction foo()\nend\n"
+        @test ds(src_other) == src_other
+    end
+
+    # Unclosed fence: left untouched
+    src_unclosed = "\"\"\"\n```julia\nx=1\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_unclosed) == src_unclosed
+
+    # Idempotency
+    src_formatted = "\"\"\"\n```julia\nx = 1\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_formatted) == src_formatted
+
+    # Indented docstring (inside module)
+    src_mod = "module M\n\"\"\"\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\nend\n"
+    @test ds(src_mod) == "module M\n\"\"\"\n```julia\nx = 1\n```\n\"\"\"\nfunction foo()\nend\nend\n"
+
+    # Single-quoted docstring: left untouched
+    src_single = "\"Docs.\"\nfunction foo()\nend\n"
+    @test ds(src_single) == src_single
+
+    # raw"""...""" docstring: left untouched (no K"doc" wrapper, lineage macro is not @doc)
+    src_raw = "raw\"\"\"\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_raw) == src_raw
+
+    # Interpolated docstrings are left untouched (K"$"/K"Identifier" kids would otherwise
+    # be silently dropped from the string on writeback).
+    # Prose interpolation + formattable code block
+    src_interp_prose = "\"\"\"\nHello \$name world.\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_interp_prose) == src_interp_prose
+    # Interpolation inside code block that parses after stripping (corruption would be silent)
+    src_interp_block = "\"\"\"\n```julia\nfoo( \$arg )\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_interp_block) == src_interp_block
+    # Prose interpolation + formattable signature
+    src_interp_sig = "\"\"\"\n    foo( x,y )\n\nHello \$name.\n\"\"\"\nfunction foo(x, y)\nend\n"
+    @test ds(src_interp_sig) == src_interp_sig
+
+    # Multi-line REPL with continuation
+    src_repl_multi = "\"\"\"\n```julia-repl\njulia> function f()\n           x=1\n       end\nnothing\n```\n\"\"\"\nfunction foo()\nend\n"
+    r = ds(src_repl_multi)
+    @test occursin("julia> function f()", r)
+    @test occursin("x = 1", r)
+    @test occursin("nothing", r)
+
+    # Indented code block: all lines keep their indent after formatting
+    src_indent = "\"\"\"\nSome docs.\n\n    ```julia\n    1+1\n    2+1\n    ```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_indent) == "\"\"\"\nSome docs.\n\n    ```julia\n    1 + 1\n    2 + 1\n    ```\n\"\"\"\nfunction foo()\nend\n"
+
+    # Indented code block (issue.jl pattern): admonition with indented fence
+    src_issue = "\"\"\"\n    foo()\n\nDo foo.\n\n!!! note\n    Here is a note with indented code block.\n    ```julia\n    1+1\n    2+1\n    ```\n\"\"\"\nfunction foo()\nend\n"
+    r_issue = ds(src_issue)
+    @test occursin("    1 + 1\n", r_issue)
+    @test occursin("    2 + 1\n", r_issue)
+
+    # Indented jldoctest block: indent is preserved
+    src_indent_jld = "\"\"\"\n    ```jldoctest\n    julia> 1+1\n    2\n    ```\n\"\"\"\nfunction foo()\nend\n"
+    r_jld = ds(src_indent_jld)
+    @test occursin("    julia> 1 + 1\n", r_jld)
+    @test occursin("    2\n", r_jld)
+
+    # No leading newline after opening """ (content starts on the opening line)
+    src_noleadnl = "\"\"\"Summary.\n```julia\nx=1\n```\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_noleadnl) ==
+        "\"\"\"Summary.\n```julia\nx = 1\n```\n\"\"\"\nfunction foo()\nend\n"
+
+    # Nested fences: a julia block nested inside a wider non-julia outer fence must NOT
+    # be formatted (the outer fence makes the inner one a literal text example).
+    src_nested_md = "\"\"\"\n````markdown\n```julia\n1+1\n```\n````\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_nested_md) == src_nested_md
+    # Same but outer fence has no language tag
+    src_nested_nolang = "\"\"\"\n````\n```julia\n1+1\n```\n````\n\"\"\"\nfunction foo()\nend\n"
+    @test ds(src_nested_nolang) == src_nested_nolang
+end
+
 module RunicMain1
     using Test: @testset
     using Runic: main


### PR DESCRIPTION
Introduce an opt-in `--docstrings` CLI flag (and matching `docstrings::Bool` keyword argument on `format_string` / `format_file`) that formats Julia code embedded in docstrings. Fenced `julia`, `julia-repl`, and `jldoctest` blocks are passed through Runic; CommonMark indented code blocks (including leading method signatures) are formatted too.

Closes #174.