### PR TITLE
Formatting of Julia code in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    have their contents run through Runic. All indented markdown code blocks (including
    leading method signatures) are also formatted (and thus assumed to be Julia code blocks).
    ([#174], [#196])
+ - Markdown file formatting. Files with the `.md` extension are formatted by rewriting
+   the embedded Julia code blocks (same rules as `--docstrings`), leaving prose alone.
+   Dispatch is by extension: `runic foo.md` (or `Runic.format_file("foo.md")`) goes
+   through the Markdown path, stdin dispatches via `--stdin-filename=*.md`, and
+   directory walks use the new `--extensions=<list>` flag (default `jl`, e.g.
+   `--extensions=jl,md` to walk both). `--lines` is supported with block-granular
+   semantics: any code block whose line range overlaps a `--lines` range is formatted
+   in full. ([#197])
 
 ## [v1.6.1] - 2026-04-16
 ### Fixed
@@ -231,3 +239,4 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#193]: https://github.com/fredrikekre/Runic.jl/pull/193
 [#194]: https://github.com/fredrikekre/Runic.jl/pull/194
 [#196]: https://github.com/fredrikekre/Runic.jl/pull/196
+[#197]: https://github.com/fredrikekre/Runic.jl/pull/197

--- a/src/Runic.jl
+++ b/src/Runic.jl
@@ -665,13 +665,30 @@ function format_file(inputfile::AbstractString, outputfile::AbstractString = inp
     if !inplace && (outputfile == inputfile || (isfile(outputfile) && samefile(inputfile, outputfile)))
         error("input and output must not be the same when `inplace = false`")
     end
-    # Format it
+    # Format it!
+    # Dispatch on extension: `.md` goes through the Markdown formatter.
+    if endswith(inputfile, ".md")
+        format_markdown_file(str, outputfile; inplace = inplace)
+        return
+    end
     ctx = Context(str; filename = inputfile, docstrings = docstrings)
     format_tree!(ctx)
     # Write the output but skip if it text didn't change
     changed = ctx.fmt_tree !== nothing
     if changed || !inplace
         write(outputfile, take!(ctx.fmt_io))
+    end
+    return
+end
+
+# Internal: Markdown branch of `format_file`. Takes the already-read source string and
+# an output path — argument handling (normalization, samefile check) lives in
+# `format_file`. Not part of the public API; call `format_file` instead, which
+# dispatches on extension.
+function format_markdown_file(str::AbstractString, outputfile::AbstractString; inplace::Bool = false)
+    formatted = format_markdown(String(str))
+    if formatted != str || !inplace
+        write(outputfile, formatted)
     end
     return
 end

--- a/src/main.jl
+++ b/src/main.jl
@@ -39,7 +39,7 @@ function tryf(f::F, arg, default) where {F}
         return default
     end
 end
-function scandir!(files, root)
+function scandir!(files, root, extensions::Vector{String})
     # Don't recurse into `.git`. If e.g. a branch name ends with `.jl` there are files
     # inside of `.git` which has the `.jl` extension, but they are not Julia source files.
     if occursin(".git", root) && ".git" in splitpath(root)
@@ -52,14 +52,15 @@ function scandir!(files, root)
         jf = joinpath(root, f)
         if tryf(isdir, jf, false)
             push!(dirs, f)
-        elseif (tryf(isfile, jf, false) || tryf(islink, jf, false)) && endswith(jf, ".jl")
+        elseif (tryf(isfile, jf, false) || tryf(islink, jf, false)) &&
+                any(e -> endswith(jf, e), extensions)
             push!(files, jf)
         else
             # Ignore it I guess...
         end
     end
     for dir in dirs
-        scandir!(files, joinpath(root, dir))
+        scandir!(files, joinpath(root, dir), extensions)
     end
     return
 end
@@ -122,7 +123,7 @@ function print_help()
         io, """
                <path>...
                    Input path(s) (files and/or directories) to process. For directories,
-                   all files (recursively) with the '*.jl' suffix are used as input files.
+                   all files matching `--extensions` are collected recursively.
                    If no path is given, or if path is `-`, input is read from stdin.
 
                -c, --check
@@ -132,6 +133,15 @@ function print_help()
                -d, --diff
                    Print the diff between the input and formatted output to stderr.
                    Requires `git` to be installed.
+
+               --docstrings
+                   Format code blocks in docstrings embedded in source files.
+
+               --extensions=<ext>[,<ext>...]
+                   Comma-separated list of file extensions to collect when walking
+                   directories. Defaults to `jl`. Use e.g. `--extensions=jl,md` to
+                   pick up both Julia and Markdown files. Explicit file paths bypass this
+                   filter.
 
                --help
                    Print this message.
@@ -148,16 +158,14 @@ function print_help()
                    is `-`, output is written to stdout.
 
                --stdin-filename=<filename>
-                   Assumed filename when formatting from stdin. Used for error messages.
+                   Assumed filename when formatting from stdin. Used for error messages
+                   and for inferring whether input is Julia or Markdown.
 
                -v, --verbose
                    Enable verbose output.
 
                --version
                    Print Runic and julia version information.
-
-               --docstrings
-                   Format code blocks in docstrings embedded in source files.
         """
     )
     return
@@ -217,6 +225,48 @@ function insert_line_range(line_ranges, lines)
     return 0
 end
 
+# Format a Markdown input string. Returns `(changed, fmt_iob, src_str_for_diff)`.
+function format_markdown_input(sourcetext::String; line_ranges::Vector{UnitRange{Int}})
+    fmt_str = format_markdown(sourcetext; line_ranges = line_ranges)
+    return (fmt_str != sourcetext, IOBuffer(fmt_str), sourcetext)
+end
+
+# Format a Julia source input. Returns `(changed, fmt_iob, src_str_for_diff)` with
+# line-range comment markers stripped from the diff-side source string.
+function format_julia_input(
+        sourcetext::String, inputfile_pretty::String;
+        quiet::Bool, verbose::Bool, debug::Bool, diff::Bool, check::Bool,
+        docstrings::Bool, line_ranges::Vector{UnitRange{Int}},
+    )
+    ctx = Context(
+        sourcetext; quiet, verbose, debug, diff, check, docstrings, line_ranges,
+        filename = inputfile_pretty,
+    )
+    format_tree!(ctx)
+    changed = !nodes_equal(ctx.fmt_tree, ctx.src_tree)
+    fmt_iob = seekstart(ctx.fmt_io)
+    src_str_for_diff = ctx.src_str
+    # The diff side of `src_str_for_diff` is only consumed when we're actually rendering
+    # a diff, i.e. `diff && changed` (see the main loop). Strip the range markers only
+    # when needed; otherwise return the raw source and save the allocation.
+    # TODO: It isn't great that the source string has been modified to begin with, and
+    #       to support --lines in the API functions this filtering needs to be moved
+    #       to the `format_tree` function.
+    if diff && changed && !isempty(line_ranges)
+        io = IOBuffer(; sizehint = sizeof(src_str_for_diff))
+        for line in eachline(IOBuffer(src_str_for_diff); keep = true)
+            if !(
+                    occursin(RANGE_FORMATTING_BEGIN, line) ||
+                        occursin(RANGE_FORMATTING_END, line)
+                )
+                write(io, line)
+            end
+        end
+        src_str_for_diff = String(take!(io))
+    end
+    return (changed, fmt_iob, src_str_for_diff)
+end
+
 function main(argv)
     # Reset errno
     global errno = 0
@@ -236,6 +286,7 @@ function main(argv)
     line_ranges = typeof(1:2)[]
     input_is_stdin = true
     multiple_inputs = false
+    extensions = [".jl"]
 
     # Parse the arguments
     while length(argv) > 0
@@ -268,6 +319,18 @@ function main(argv)
             end
         elseif (m = match(r"^--stdin-filename=(.+)$", x); m !== nothing)
             stdin_filename = String(m.captures[1]::SubString)
+        elseif (m = match(r"^--extensions=(.+)$", x); m !== nothing)
+            raw = String(m.captures[1]::SubString)
+            empty!(extensions)
+            for part in split(raw, ',')
+                s = strip(part)
+                isempty(s) && continue
+                # Accept both `jl` and `.jl`; store as `.jl` for endswith comparison.
+                push!(extensions, startswith(s, ".") ? String(s) : "." * String(s))
+            end
+            if isempty(extensions)
+                return panic("`--extensions` requires at least one extension")
+            end
         elseif x == "-o"
             if length(argv) < 1
                 return panic("expected output file argument after `-o`")
@@ -289,7 +352,7 @@ function main(argv)
                 else
                     input_is_stdin = false
                     if isdir(x)
-                        scandir!(inputfiles, x)
+                        scandir!(inputfiles, x, extensions)
                         # Directories are considered to be multiple (potential) inputs even
                         # if they end up being empty
                         multiple_inputs = true
@@ -417,15 +480,23 @@ function main(argv)
             end
         end
 
-        # Call the library to format the text
+        # Determine per-file format mode. Dispatch is by file extension; for stdin the
+        # virtual filename from `--stdin-filename` is used.
         inputfile_pretty = inputfile == "-" ? stdin_filename : inputfile
-        ctx = try
-            ctx′ = Context(
-                sourcetext; quiet, verbose, debug, diff, check, docstrings, line_ranges,
-                filename = inputfile_pretty,
-            )
-            format_tree!(ctx′)
-            ctx′
+        is_md = endswith(inputfile_pretty, ".md")
+
+        # Call the library to format the text. Both branches produce
+        # `(changed, fmt_iob, src_str_for_diff)`. Errors propagate; the catch below
+        # handles them uniformly.
+        changed, fmt_iob, src_str_for_diff = try
+            if is_md
+                format_markdown_input(sourcetext; line_ranges)
+            else
+                format_julia_input(
+                    sourcetext, inputfile_pretty;
+                    quiet, verbose, debug, diff, check, docstrings, line_ranges,
+                )
+            end
         catch err
             print_progress && errln()
             if err isa JuliaSyntax.ParseError
@@ -452,7 +523,6 @@ function main(argv)
         end
 
         # Output the result
-        changed = !nodes_equal(ctx.fmt_tree, ctx.src_tree)
         if check
             if changed
                 print_progress && errln()
@@ -463,7 +533,7 @@ function main(argv)
         elseif changed || !inplace
             @assert output.which !== :devnull
             try
-                writeo(output, seekstart(ctx.fmt_io))
+                writeo(output, fmt_iob)
             catch err
                 print_progress && errln()
                 panic("could not write to output file `$(output.file)`: ", err)
@@ -480,39 +550,22 @@ function main(argv)
                 file = basename(inputfile)
                 A = joinpath(a, file)
                 B = joinpath(b, file)
-                src_str = ctx.src_str
-                # If we have ranges we need to remove the comment markers
-                # TODO: It isn't great that the source string has been modified to begin
-                #       with, and to support --lines in the API functions this filtering
-                #       needs to be moved to the `format_tree` function.
-                if !isempty(line_ranges)
-                    io = IOBuffer(; sizehint = sizeof(src_str))
-                    for line in eachline(IOBuffer(src_str); keep = true)
-                        if !(
-                                occursin(RANGE_FORMATTING_BEGIN, line) ||
-                                    occursin(RANGE_FORMATTING_END, line)
-                            )
-                            write(io, line)
-                        end
-                    end
-                    src_str = String(take!(io))
-                end
                 # juliac: `open(...) do` uses dynamic dispatch otherwise the following
                 # blocks could be written as
                 # ```
-                # write(A, src_str)
-                # write(B, seekstart(ctx.fmt_io))
+                # write(A, src_str_for_diff)
+                # write(B, seekstart(fmt_iob))
                 # ```
                 let io = open(A, "w")
                     try
-                        write(io, src_str)
+                        write(io, src_str_for_diff)
                     finally
                         close(io)
                     end
                 end
                 let io = open(B, "w")
                     try
-                        write(io, seekstart(ctx.fmt_io))
+                        write(io, seekstart(fmt_iob))
                     finally
                         close(io)
                     end

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -3412,9 +3412,14 @@ end
 
 # Identify julia source code blocks (``` blocks four-space-indent blocks),
 # collect the lines, format the text and re-insert
-function format_markdown(s::String)
+function format_markdown(s::String; line_ranges::Vector{UnitRange{Int}} = UnitRange{Int}[])
     lines = collect(eachline(IOBuffer(s); keep = true))
     isempty(lines) && return s
+    # A block at lines `a:b` is formatted iff `line_ranges` is empty (no filter) or at
+    # least one range overlaps the block. Block-granular: partial blocks are formatted
+    # in full when any line within overlaps.
+    in_range(a, b) = isempty(line_ranges) ||
+        any(r -> !isdisjoint(r, a:b), line_ranges)
     # Indented code blocks (CommonMark "indented" style) are handled like implicit
     # fences: opener is blank-line-or-start-of-docstring followed by a non-blank line
     # with >= 4 leading spaces; content = consecutive non-blank 4-space-indented lines;
@@ -3444,6 +3449,13 @@ function format_markdown(s::String)
                 break
             end
             block_lines = lines[(i + 1):(close_i - 1)]
+            # Skip if `--lines` doesn't overlap this block's full extent.
+            if !in_range(i, close_i)
+                append!(result, @view lines[i:close_i])
+                i = close_i + 1
+                at_boundary = false
+                continue
+            end
             # Non-Julia fence: copy through unchanged
             if !is_julia_lang(lang)
                 append!(result, @view lines[i:close_i])
@@ -3499,6 +3511,12 @@ function format_markdown(s::String)
                 else
                     break
                 end
+            end
+            if !in_range(i, end_idx)
+                append!(result, @view lines[i:end_idx])
+                i = end_idx + 1
+                at_boundary = false
+                continue
             end
             # Strip the indent; normalize blank lines to "\n" (explicit trailing spaces
             # on blank lines are not meaningful and chop would swallow the '\n').

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -577,6 +577,108 @@ function maintests(f::R) where {R}
         @test isempty(fd2)
     end
 
+    # runic Markdown stdin dispatch via --stdin-filename
+    let src_md = "```julia\nx=1\n```\n",
+            expected_md = "```julia\nx = 1\n```\n"
+        # Default (no stdin-filename) treats input as Julia — this one would ParseError
+        # since the source contains a code fence. Confirm with a simple source instead.
+        rc, fd1, fd2 = runic(["--stdin-filename=foo.md"], src_md)
+        @test rc == 0
+        @test fd1 == expected_md
+        @test isempty(fd2)
+        # Without .md extension, falls back to Julia (backticks parse as Cmd literal, no change)
+        rc, fd1, fd2 = runic(["--stdin-filename=foo.jl"], src_md)
+        @test rc == 0
+        @test fd1 == src_md
+    end
+
+    # runic --extensions for directory walking
+    mktempdir() do dir
+        write(joinpath(dir, "a.jl"), "x=1\n")
+        write(joinpath(dir, "b.md"), "```julia\nx=1\n```\n")
+
+        # Default (only .jl): check finds the .jl file unformatted, ignores .md
+        rc, fd1, fd2 = runic(["--check", dir])
+        @test rc == 1  # .jl needs formatting
+
+        # Format .jl, leave .md alone
+        rc, fd1, fd2 = runic(["-i", dir])
+        @test rc == 0
+        @test read(joinpath(dir, "a.jl"), String) == "x = 1\n"
+        @test read(joinpath(dir, "b.md"), String) == "```julia\nx=1\n```\n"  # untouched
+
+        # Restore mangled input for the next leg
+        write(joinpath(dir, "a.jl"), "x=1\n")
+
+        # Extension filter for .md only
+        rc, fd1, fd2 = runic(["--extensions=md", "-i", dir])
+        @test rc == 0
+        @test read(joinpath(dir, "a.jl"), String) == "x=1\n"  # untouched
+        @test read(joinpath(dir, "b.md"), String) == "```julia\nx = 1\n```\n"
+
+        # Both extensions
+        write(joinpath(dir, "b.md"), "```julia\nx=1\n```\n")  # re-mangle
+        rc, fd1, fd2 = runic(["--extensions=jl,md", "-i", dir])
+        @test rc == 0
+        @test read(joinpath(dir, "a.jl"), String) == "x = 1\n"
+        @test read(joinpath(dir, "b.md"), String) == "```julia\nx = 1\n```\n"
+    end
+
+    # Explicit .md path bypasses the extension filter (format it regardless)
+    mktempdir() do dir
+        md = joinpath(dir, "doc.md")
+        write(md, "```julia\nx=1\n```\n")
+        rc, fd1, fd2 = runic(["-i", md])
+        @test rc == 0
+        @test read(md, String) == "```julia\nx = 1\n```\n"
+    end
+
+    # --lines works with Markdown (block-granular overlap)
+    # Two blocks in the source; range overlaps only the second → only that one formatted.
+    let src = "```julia\nx=1\n```\n\n```julia\ny=2\n```\n",
+            expected = "```julia\nx=1\n```\n\n```julia\ny = 2\n```\n"
+        # Second block occupies lines 5..7; selecting line 6 overlaps that block only.
+        rc, fd1, fd2 = runic(["--lines=6:6", "--stdin-filename=foo.md"], src)
+        @test rc == 0
+        @test fd1 == expected
+    end
+    # Range entirely in prose → no change
+    let src = "prose line\n\n```julia\nx=1\n```\n\nmore prose\n"
+        rc, fd1, fd2 = runic(["--lines=1:1", "--stdin-filename=foo.md"], src)
+        @test rc == 0
+        @test fd1 == src
+    end
+    # Range partially crossing a block → whole block formatted (block-granular rule)
+    let src = "prose\n\n```julia\nx=1\ny=2\n```\n",
+            expected = "prose\n\n```julia\nx = 1\ny = 2\n```\n"
+        # Range 1..4 covers the prose line + fence opener + first content line; block
+        # starts at line 3. Any overlap → full block formatted.
+        rc, fd1, fd2 = runic(["--lines=1:4", "--stdin-filename=foo.md"], src)
+        @test rc == 0
+        @test fd1 == expected
+    end
+
+    # --check for Markdown: returns 1 when reformatting would change the file
+    let (rc, fd1, fd2) = runic(["--check", "--stdin-filename=foo.md"], "```julia\nx=1\n```\n")
+        @test rc == 1
+    end
+    # --check for Markdown: returns 0 when already formatted
+    let (rc, fd1, fd2) = runic(["--check", "--stdin-filename=foo.md"], "```julia\nx = 1\n```\n")
+        @test rc == 0
+    end
+
+    # --diff for Markdown produces a diff
+    let (rc, fd1, fd2) = runic(["--diff", "--stdin-filename=foo.md"], "```julia\nx=1\n```\n")
+        @test rc == 0
+        @test occursin("-x=1", fd2) || occursin("x=1", fd2)
+        @test occursin("+x = 1", fd2) || occursin("x = 1", fd2)
+    end
+
+    # --extensions with invalid (empty) input
+    let (rc, fd1, fd2) = runic(["--extensions=", "."])
+        @test rc != 0
+    end
+
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1853,6 +1853,85 @@ end
     @test ds(src_nested_nolang) == src_nested_nolang
 end
 
+@testset "markdown" begin
+    # format_markdown is a pure text->text function (no Context), reused from docstrings.
+    fm = Runic.format_markdown
+
+    # Plain prose passes through unchanged
+    @test fm("Just prose.\n") == "Just prose.\n"
+
+    # Fenced julia block gets formatted; prose left alone
+    src = "# Title\n\nSome prose.\n\n```julia\nx=1\n```\n\nMore prose.\n"
+    out = "# Title\n\nSome prose.\n\n```julia\nx = 1\n```\n\nMore prose.\n"
+    @test fm(src) == out
+
+    # Non-Julia fence left untouched
+    @test fm("```python\nx=1\n```\n") == "```python\nx=1\n```\n"
+
+    # jldoctest block with julia> prompts formatted
+    src_jld = "```jldoctest\njulia> x=1\n1\n```\n"
+    out_jld = "```jldoctest\njulia> x = 1\n1\n```\n"
+    @test fm(src_jld) == out_jld
+
+    # Indented code block (CommonMark style) formatted as Julia
+    src_ind = "Prose.\n\n    x=1\n\nMore prose.\n"
+    out_ind = "Prose.\n\n    x = 1\n\nMore prose.\n"
+    @test fm(src_ind) == out_ind
+
+    # Invalid Julia inside a fence: left untouched (ParseError swallowed)
+    src_bad = "```julia\nx = 1 +\n```\n"
+    @test fm(src_bad) == src_bad
+
+    # Idempotency: an already-formatted file is unchanged
+    @test fm(out) == out
+    @test fm(out_jld) == out_jld
+    @test fm(out_ind) == out_ind
+
+    # format_file auto-dispatches to the Markdown path on .md extension
+    mktempdir() do dir
+        path = joinpath(dir, "doc.md")
+        write(path, src)
+        Runic.format_file(path; inplace = true)
+        @test read(path, String) == out
+    end
+
+    # format_file with separate output file
+    mktempdir() do dir
+        in_path = joinpath(dir, "in.md")
+        out_path = joinpath(dir, "out.md")
+        write(in_path, src)
+        Runic.format_file(in_path, out_path)
+        @test read(out_path, String) == out
+        @test read(in_path, String) == src  # input untouched
+    end
+
+    # Idempotent input via format_file: already-formatted content stays the same.
+    mktempdir() do dir
+        path = joinpath(dir, "doc.md")
+        write(path, out)
+        Runic.format_file(path; inplace = true)
+        @test read(path, String) == out
+    end
+
+    # `line_ranges` keyword — block-granular overlap filter
+    let src = "```julia\nx=1\n```\n\n```julia\ny=2\n```\n"
+        # Second block (lines 5..7): format only it
+        @test fm(src; line_ranges = [6:6]) ==
+            "```julia\nx=1\n```\n\n```julia\ny = 2\n```\n"
+        # First block (lines 1..3): format only it
+        @test fm(src; line_ranges = [2:2]) ==
+            "```julia\nx = 1\n```\n\n```julia\ny=2\n```\n"
+        # Both blocks via a single wide range
+        @test fm(src; line_ranges = [1:7]) ==
+            "```julia\nx = 1\n```\n\n```julia\ny = 2\n```\n"
+        # No overlap with prose-only line between blocks
+        @test fm(src; line_ranges = [4:4]) == src
+        # Multiple ranges union
+        @test fm(src; line_ranges = [2:2, 6:6]) ==
+            "```julia\nx = 1\n```\n\n```julia\ny = 2\n```\n"
+    end
+end
+
 module RunicMain1
     using Test: @testset
     using Runic: main


### PR DESCRIPTION
Extend Runic to format Julia code blocks inside Markdown (`.md`) files. The file dispatch is by extension: `runic foo.md` (or `Runic.format_file("foo.md")`) formats only the embedded Julia code blocks (same rules as `--docstrings`), leaving the surrounding prose untouched. Stdin can be routed through the Markdown formatter by passing `--stdin-filename=*.md`.

Directory walks are controlled by a new `--extensions=<list>` flag (default `jl`, e.g. `--extensions=jl,md` to walk both). Explicit file paths always bypass this filter. `--lines` is supported with block- granular semantics: any code block whose line range overlaps a `--lines` range is formatted in full; blocks outside are left untouched.

Closes #197.