### PR TITLE
Add safety checks for directory recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+ - Safety checks for directory recursion. When collecting files from a directory Runic now
+   errors if the home directory or a Julia depot subdirectory (e.g. `~/.julia/packages`,
+   `~/.julia/dev`) is encountered, whether given as the input path or reached recursively,
+   and silently skips nested git repositories (e.g. git submodules and vendored clones).
+   The new `--recurse` flag includes nested git repositories in the walk and the new
+   `--force-recurse` flag disables all checks. ([#200])
 ### Fixed
  - `# runic: off` / `# runic: on` toggles now work as expected also when the toggle comments
    are direct children of a listlike expression (tuples, function calls, `[ ]`, `{ }`, ...)
@@ -256,4 +263,5 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#194]: https://github.com/fredrikekre/Runic.jl/issues/194
 [#196]: https://github.com/fredrikekre/Runic.jl/issues/196
 [#197]: https://github.com/fredrikekre/Runic.jl/issues/197
+[#200]: https://github.com/fredrikekre/Runic.jl/issues/200
 [#210]: https://github.com/fredrikekre/Runic.jl/issues/210

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.8.0] - 2026-08-14
 ### Added
  - Safety checks for directory recursion. When collecting files from a directory Runic now
    errors if the home directory or a Julia depot subdirectory (e.g. `~/.julia/packages`,
    `~/.julia/dev`) is encountered, whether given as the input path or reached recursively,
    and silently skips nested git repositories (e.g. git submodules and vendored clones).
    The new `--recurse` flag includes nested git repositories in the walk and the new
-   `--force-recurse` flag disables all checks. ([#200])
+   `--force-recurse` flag disables all checks. ([#200], [#211])
 ### Fixed
  - `# runic: off` / `# runic: on` toggles now work as expected also when the toggle comments
    are direct children of a listlike expression (tuples, function calls, `[ ]`, `{ }`, ...)
@@ -224,6 +224,7 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [v1.6.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.6.0
 [v1.6.1]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.6.1
 [v1.7.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.7.0
+[v1.8.0]: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.8.0
 [#97]: https://github.com/fredrikekre/Runic.jl/issues/97
 [#108]: https://github.com/fredrikekre/Runic.jl/issues/108
 [#109]: https://github.com/fredrikekre/Runic.jl/issues/109
@@ -265,3 +266,4 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#197]: https://github.com/fredrikekre/Runic.jl/issues/197
 [#200]: https://github.com/fredrikekre/Runic.jl/issues/200
 [#210]: https://github.com/fredrikekre/Runic.jl/issues/210
+[#211]: https://github.com/fredrikekre/Runic.jl/issues/211

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Runic"
 uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ runic --help    # Show documentation
 
 ```sh
 # Format all files in-place in the current directory (recursively)
-# !! DON'T DO THIS FROM YOUR HOME DIRECTORY !!
 runic --inplace .
 ```
+
+> [!NOTE]
+> When walking directories Runic refuses to recurse into your home directory and into Julia
+> depot subdirectories (e.g. `~/.julia/packages`), and skips nested git repositories (e.g.
+> git submodules). Pass `--recurse` to include nested git repositories and `--force-recurse` to
+> disable all checks.
 
 <details>
 <summary>Legacy installation instructions</summary>
@@ -156,6 +161,11 @@ OPTIONS
            pick up both Julia and Markdown files. Explicit file paths bypass this
            filter.
 
+       --force-recurse
+           Disable the safety checks that prevent formatting of the home
+           directory and Julia depot subdirectories (e.g. `~/.julia/packages`).
+           Implies `--recurse`.
+
        --help
            Print this message.
 
@@ -169,6 +179,11 @@ OPTIONS
        -o <file>, --output=<file>
            File to write formatted output to. If no output is given, or if the file
            is `-`, output is written to stdout.
+
+       --recurse
+           Recurse into nested git repositories (e.g. git submodules and vendored
+           clones) when walking directories. By default nested git repositories
+           are skipped.
 
        --stdin-filename=<filename>
            Assumed filename when formatting from stdin. Used for error messages

--- a/src/main.jl
+++ b/src/main.jl
@@ -3,6 +3,8 @@
 # Return code of main
 errno::Cint = 0
 
+using Base.Filesystem: StatStruct
+
 # Check whether we are compiling with juliac
 using Preferences: @load_preference
 const juliac = @load_preference("juliac", false)
@@ -39,14 +41,92 @@ function tryf(f::F, arg, default) where {F}
         return default
     end
 end
-function scandir!(files, root, extensions::Vector{String})
+
+# Stats of directories that are protected in directory recursion
+struct Guard
+    home::StatStruct
+    depots::Vector{StatStruct}
+end
+
+function Guard()
+    depots = Vector{StatStruct}()
+    for depot in Base.DEPOT_PATH
+        st = tryf(stat, depot, StatStruct())
+        isdir(st) && push!(depots, st)
+    end
+    homepath = try
+        homedir()
+    catch
+        ""
+    end
+    if !isempty(homepath)
+        st = tryf(stat, joinpath(homepath, ".julia"), StatStruct())
+        if isdir(st) && !any(depot -> samefile(st, depot), depots)
+            push!(depots, st)
+        end
+    end
+    return Guard(tryf(stat, homepath, StatStruct()), depots)
+end
+
+# Directories that Runic refuses to recurse into: the home directory and Julia depots
+# (including their immediate subdirectories). These result in an error wherever they are
+# encountered in the walk, whether given as the input path or reached recursively.
+function protected_directory(guard::Guard, dir::String)
+    # `dir` exists (the caller checks `isdir`) but `stat` can still fail (e.g. removed
+    # concurrently). This is safe: `samefile` requires `ispath` for both arguments so
+    # zeroed `StatStruct`s (failed `stat`, unknown home directory) never compare equal,
+    # not even to each other.
+    st = tryf(stat, dir, StatStruct())
+    # The home directory itself (formatting e.g. `~/dev/Runic.jl` is still fine)
+    if samefile(st, guard.home)
+        return true
+    end
+    # Julia depots and their immediate subdirectories (`packages`, `dev`, `clones`, `logs`,
+    # ...). Note that this still allows formatting of e.g. `~/.julia/dev/MyPackage` since
+    # that is a common place to keep development checkouts.
+    parent = tryf(stat, joinpath(dir, ".."), StatStruct())
+    for depot in guard.depots
+        if samefile(st, depot) || samefile(parent, depot)
+            return true
+        end
+    end
+    return false
+end
+
+function scandir!(
+        files, root, extensions::Vector{String};
+        recurse::Bool = false, force_recurse::Bool = false, isroot::Bool = true,
+        guard::Guard,
+    )
     # Don't recurse into `.git`. If e.g. a branch name ends with `.jl` there are files
     # inside of `.git` which has the `.jl` extension, but they are not Julia source files.
     if occursin(".git", root) && ".git" in splitpath(root)
         @assert endswith(root, ".git")
-        return
+        return 0
     end
-    tryf(isdir, root, false) || return
+    tryf(isdir, root, false) || return 0
+    if !force_recurse
+        # The home directory and Julia depots are refused with an error wherever they are
+        # encountered in the walk (e.g. `runic -i /` errors when the walk reaches the home
+        # directory).
+        if protected_directory(guard, String(root))
+            msg = string(
+                "refusing to recurse into `", root, "`, use `--force-recurse` to override"
+            )
+            return panic(msg)
+        end
+        # Nested git repositories (git submodules, vendored clones, ...) are silently
+        # skipped (`--recurse` includes them). Directories listed explicitly on the
+        # command line are walked in their own right (as roots), since formatting the
+        # repository you are currently in is the most common usecase. `.git` is a
+        # directory in a regular clone and a file in e.g. submodules and linked worktrees.
+        if !isroot && !recurse
+            dotgit = joinpath(root, ".git")
+            if tryf(isdir, dotgit, false) || tryf(isfile, dotgit, false)
+                return 0
+            end
+        end
+    end
     dirs = Vector{String}()
     for f in tryf(readdir, root, String[])
         jf = joinpath(root, f)
@@ -60,9 +140,14 @@ function scandir!(files, root, extensions::Vector{String})
         end
     end
     for dir in dirs
-        scandir!(files, joinpath(root, dir), extensions)
+        rc = scandir!(
+            files, joinpath(root, dir), extensions;
+            recurse = recurse, force_recurse = force_recurse, isroot = false,
+            guard = guard,
+        )
+        rc == 0 || return rc
     end
-    return
+    return 0
 end
 
 function panic(
@@ -143,6 +228,11 @@ function print_help()
                    pick up both Julia and Markdown files. Explicit file paths bypass this
                    filter.
 
+               --force-recurse
+                   Disable the safety checks that prevent formatting of the home
+                   directory and Julia depot subdirectories (e.g. `~/.julia/packages`).
+                   Implies `--recurse`.
+
                --help
                    Print this message.
 
@@ -156,6 +246,11 @@ function print_help()
                -o <file>, --output=<file>
                    File to write formatted output to. If no output is given, or if the file
                    is `-`, output is written to stdout.
+
+               --recurse
+                   Recurse into nested git repositories (e.g. git submodules and vendored
+                   clones) when walking directories. By default nested git repositories
+                   are skipped.
 
                --stdin-filename=<filename>
                    Assumed filename when formatting from stdin. Used for error messages
@@ -283,6 +378,8 @@ function main(argv)
     check = false
     docstrings = false
     fail_fast = false
+    recurse = false
+    force_recurse = false
     line_ranges = typeof(1:2)[]
     input_is_stdin = true
     multiple_inputs = false
@@ -311,6 +408,11 @@ function main(argv)
             check = true
         elseif x == "--docstrings"
             docstrings = true
+        elseif x == "--recurse"
+            recurse = true
+        elseif x == "--force-recurse"
+            force_recurse = true
+            recurse = true # --force-recurse implies --recurse
         elseif x == "-vv" || x == "--debug"
             debug = verbose = true
         elseif (m = match(r"^--lines=(.*)$", x); m !== nothing)
@@ -340,6 +442,7 @@ function main(argv)
             outputfile = String(m.captures[1]::SubString)
         else
             # Remaining arguments must be `-`, files, or directories
+            guard = Guard()
             first = true
             while true
                 if x == "-"
@@ -352,7 +455,13 @@ function main(argv)
                 else
                     input_is_stdin = false
                     if isdir(x)
-                        scandir!(inputfiles, x, extensions)
+                        if scandir!(
+                                inputfiles, x, extensions;
+                                recurse = recurse, force_recurse = force_recurse,
+                                guard = guard,
+                            ) != 0
+                            return errno
+                        end
                         # Directories are considered to be multiple (potential) inputs even
                         # if they end up being empty
                         multiple_inputs = true

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -3,7 +3,34 @@
 using Test: @test
 using Runic: Runic
 
+# Entrypoint which points `homedir()` to a temporary directory for the duration of the
+# tests so that Runic never operates on the real home directory, even if a test (or Runic
+# itself) misbehaves. If `homedir()` can not be redirected through the environment the
+# tests still run: `assert_not_real_home` below guards every runic invocation either way.
 function maintests(f::R) where {R}
+    real_home = try
+        realpath(homedir())
+    catch
+        ""
+    end
+    mktempdir() do fake_home
+        env_keys = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"]
+        old_env = [get(ENV, k, nothing) for k in env_keys]
+        try
+            ENV["HOME"] = ENV["USERPROFILE"] = fake_home
+            delete!(ENV, "HOMEDRIVE")
+            delete!(ENV, "HOMEPATH")
+            maintests(f, real_home)
+        finally
+            for (k, v) in zip(env_keys, old_env)
+                v === nothing ? delete!(ENV, k) : (ENV[k] = v)
+            end
+        end
+    end
+    return
+end
+
+function maintests(f::R, real_home::String) where {R}
 
     bad = "1+1"
     good = "1 + 1\n"
@@ -12,10 +39,30 @@ function maintests(f::R) where {R}
     function cdtmp(f)
         return mktempdir(tmp -> cd(f, tmp))
     end
+    # Safety net: refuse to invoke runic if any input path resolves to the real home
+    # directory (or its parent). The tests run `runic --inplace` so a bug in Runic's
+    # directory protection could otherwise be disastrous. Note that `realpath` resolves
+    # relative paths (e.g. `.`) against the current working directory.
+    function assert_not_real_home(argv::Vector{String})
+        isempty(real_home) && return
+        for p in argv
+            startswith(p, "-") && continue # skip options (and stdin input `-`)
+            rp = try
+                realpath(p)
+            catch
+                continue
+            end
+            if rp == real_home || rp == dirname(real_home)
+                error("tests must not run runic on the real home directory: `$(p)`")
+            end
+        end
+        return
+    end
     function runic(std_in::String)
         return runic(String[], std_in)
     end
     function runic(argv::Vector{String} = String[], std_in::String = "")
+        assert_not_real_home(argv)
         rc, stdout_str, stderr_str = mktemp() do stdin_path, stdin
             write(stdin_path, std_in)
             mktemp() do stdout_path, stdout
@@ -675,8 +722,213 @@ function maintests(f::R) where {R}
     end
 
     # --extensions with invalid (empty) input
-    let (rc, fd1, fd2) = runic(["--extensions=", "."])
+    cdtmp() do
+        rc, fd1, fd2 = runic(["--extensions=", "."])
         @test rc != 0
+    end
+
+    # Safety checks for directory recursion (see #200)
+
+    # Temporarily point `homedir()` to `home` and, if given, replace `DEPOT_PATH` with
+    # `depot`. Returns `false` (and does nothing but warn) if `homedir()` can not be
+    # controlled through the environment on this system.
+    function withhome(f, home::String; depot::Union{String, Nothing} = nothing)
+        keys = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"]
+        old = [get(ENV, k, nothing) for k in keys]
+        old_depot_path = copy(Base.DEPOT_PATH)
+        try
+            ENV["HOME"] = ENV["USERPROFILE"] = home
+            delete!(ENV, "HOMEDRIVE")
+            delete!(ENV, "HOMEPATH")
+            if realpath(homedir()) != realpath(home)
+                @warn "`homedir()` can not be controlled through the environment on " *
+                    "this system, skipping tests that depend on the home directory"
+                return false
+            end
+            if depot !== nothing
+                push!(empty!(Base.DEPOT_PATH), depot)
+            end
+            f()
+            return true
+        finally
+            for (k, v) in zip(keys, old)
+                v === nothing ? delete!(ENV, k) : (ENV[k] = v)
+            end
+            append!(empty!(Base.DEPOT_PATH), old_depot_path)
+        end
+    end
+
+    # Nested git repositories are skipped, the root one is not
+    cdtmp() do
+        mkdir(".git")
+        mkpath(joinpath("sub", ".git"))
+        # The contents of `.git` folders are never collected, not even with
+        # --recurse/--force-recurse
+        rootgitfile = joinpath(".git", "git.jl")
+        write(rootgitfile, "this is not a Julia file")
+        subgitfile = joinpath("sub", ".git", "git.jl")
+        write(subgitfile, "this is not a Julia file")
+        f_root = "root.jl"
+        f_sub = joinpath("sub", "sub.jl")
+        write(f_root, bad)
+        write(f_sub, bad)
+        rc, fd1, fd2 = runic(["-i", "."])
+        @test rc == 0
+        @test read(f_root, String) == good
+        @test read(f_sub, String) == bad # untouched
+        @test isempty(fd2) # skipped silently
+        # ... unless --recurse is passed
+        rc, fd1, fd2 = runic(["--recurse", "-i", "."])
+        @test rc == 0
+        @test read(f_root, String) == read(f_sub, String) == good
+        @test isempty(fd2)
+        # --force-recurse implies --recurse
+        write(f_sub, bad)
+        rc, fd1, fd2 = runic(["--force-recurse", "-i", "."])
+        @test rc == 0
+        @test read(f_sub, String) == good
+        @test isempty(fd2)
+        # ... but not even --recurse/--force-recurse collect files inside `.git` folders
+        # (rc would be 1 from the parse failure if these files were collected)
+        @test read(rootgitfile, String) == "this is not a Julia file"
+        @test read(subgitfile, String) == "this is not a Julia file"
+        # A `.git` file (submodule, linked worktree) also marks a nested repository
+        rm(joinpath("sub", ".git"), recursive = true)
+        write(joinpath("sub", ".git"), "gitdir: ../.git/modules/sub\n")
+        write(f_sub, bad)
+        rc, fd1, fd2 = runic(["-i", "."])
+        @test rc == 0
+        @test read(f_sub, String) == bad # untouched
+        # Directories listed explicitly on the command line are walk roots and thus
+        # exempt from the nested git repository check
+        rc, fd1, fd2 = runic(["-i", "sub"])
+        @test rc == 0
+        @test read(f_sub, String) == good
+        write(f_sub, bad)
+        rc, fd1, fd2 = runic(["-i", ".", "sub"])
+        @test rc == 0
+        @test read(f_root, String) == read(f_sub, String) == good
+        # ... and the order of the arguments does not matter
+        write(f_root, bad)
+        write(f_sub, bad)
+        rc, fd1, fd2 = runic(["-i", "sub", "."])
+        @test rc == 0
+        @test read(f_root, String) == read(f_sub, String) == good
+        @test isempty(fd2)
+    end
+
+    # Refuse to recurse into the home directory
+    cdtmp() do
+        home = mkdir("home")
+        f_home = joinpath(home, "home.jl")
+        write(f_home, bad)
+        withhome(abspath(home)) do
+            # Explicitly passing the home directory, and `.` from within it, is an error
+            for (dir, argv) in [(".", ["-i", home]), (home, ["-i", "."])]
+                write(f_home, bad)
+                rc, fd1, fd2 = cd(() -> runic(argv), dir)
+                @test rc == 1
+                @test read(f_home, String) == bad # untouched
+                @test occursin("refusing to recurse into", fd2)
+                @test occursin("--force-recurse", fd2)
+            end
+            # ... and --recurse does not override it (only --force-recurse does)
+            rc, fd1, fd2 = runic(["--recurse", "-i", home])
+            @test rc == 1
+            @test read(f_home, String) == bad # untouched
+            @test occursin("refusing to recurse into", fd2)
+            # ... unless --force-recurse is passed
+            rc, fd1, fd2 = runic(["--force-recurse", "-i", home])
+            @test rc == 0
+            @test read(f_home, String) == good
+            # A home directory nested below the input path is also an error (e.g.
+            # `runic -i /` should error when the walk reaches the home directory), also
+            # with --recurse
+            write(f_home, bad)
+            f_other = "other.jl"
+            write(f_other, bad)
+            for argv in [["-i", "."], ["--recurse", "-i", "."]]
+                rc, fd1, fd2 = runic(argv)
+                @test rc == 1
+                @test occursin("refusing to recurse into", fd2)
+                @test read(f_home, String) == bad # untouched
+                @test read(f_other, String) == bad # untouched (the run is aborted)
+            end
+            # ... unless --force-recurse is passed
+            rc, fd1, fd2 = runic(["--force-recurse", "-i", "."])
+            @test rc == 0
+            @test read(f_home, String) == read(f_other, String) == good
+        end
+    end
+
+    # Refuse to recurse into the depot and its immediate subdirectories
+    cdtmp() do
+        home = abspath(mkdir("home"))
+        depot = mkpath(joinpath(home, ".julia"))
+        f_depot = joinpath(depot, "depot.jl")
+        write(f_depot, bad)
+        pkgdir = mkpath(joinpath(depot, "packages", "Foo", "abc123"))
+        f_pkg = joinpath(pkgdir, "pkg.jl")
+        write(f_pkg, bad)
+        devdir = mkpath(joinpath(depot, "dev", "Foo"))
+        f_dev = joinpath(devdir, "dev.jl")
+        write(f_dev, bad)
+        withhome(home) do
+            # The depot itself, and `packages`/`dev`/... below it
+            for dir in [depot, joinpath(depot, "packages"), joinpath(depot, "dev")]
+                rc, fd1, fd2 = runic(["-i", dir])
+                @test rc == 1
+                @test occursin("refusing to recurse into", fd2)
+                @test occursin("--force-recurse", fd2)
+            end
+            @test read(f_depot, String) == read(f_pkg, String) == read(f_dev, String) == bad
+            # Development checkouts below `~/.julia/dev` are still formatted
+            rc, fd1, fd2 = runic(["-i", devdir])
+            @test rc == 0
+            @test read(f_dev, String) == good
+            # ... and so is a package in `~/.julia/packages` if requested explicitly
+            rc, fd1, fd2 = runic(["-i", pkgdir])
+            @test rc == 0
+            @test read(f_pkg, String) == good
+            # --force-recurse overrides
+            rc, fd1, fd2 = runic(["--force-recurse", "-i", depot])
+            @test rc == 0
+            @test read(f_depot, String) == good
+        end
+    end
+
+    # Depots configured via `DEPOT_PATH` are also protected (not just the default
+    # `~/.julia` under the home directory)
+    cdtmp() do
+        home = abspath(mkdir("home"))
+        depot = abspath(mkpath(joinpath("custom", "depot")))
+        f_depot = joinpath(depot, "depot.jl")
+        write(f_depot, bad)
+        pkgdir = mkpath(joinpath(depot, "packages", "Foo", "abc123"))
+        f_pkg = joinpath(pkgdir, "pkg.jl")
+        write(f_pkg, bad)
+        withhome(home; depot = depot) do
+            # The depot itself and its immediate subdirectories are refused as input paths
+            for dir in [depot, joinpath(depot, "packages")]
+                rc, fd1, fd2 = runic(["-i", dir])
+                @test rc == 1
+                @test occursin("refusing to recurse into", fd2)
+            end
+            @test read(f_depot, String) == read(f_pkg, String) == bad
+            # ... and result in an error when reached recursively
+            rc, fd1, fd2 = runic(["-i", "custom"])
+            @test rc == 1
+            @test occursin("refusing to recurse into", fd2)
+            @test read(f_depot, String) == bad
+            # Deeper directories can still be formatted
+            rc, fd1, fd2 = runic(["-i", pkgdir])
+            @test rc == 0
+            @test read(f_pkg, String) == good
+            # --force-recurse overrides
+            rc, fd1, fd2 = runic(["--force-recurse", "-i", depot])
+            @test rc == 0
+            @test read(f_depot, String) == good
+        end
     end
 
     return


### PR DESCRIPTION
When collecting files from a directory Runic now refuses to recurse into

 - the home directory,
 - Julia depots and their immediate subdirectories (`~/.julia/packages`,
   `~/.julia/dev`, `~/.julia/clones`, `~/.julia/logs`, ...),
 - nested git repositories (git submodules, vendored clones, ...).

Refusing the input path itself is an error (so that e.g. `runic -i .`
from the home directory aborts instead of formatting everything below
it). Protected directories encountered further down the walk are
silently skipped; `--verbose` prints a note for each skipped directory.

Directories listed explicitly on the command line are always walked
(`runic -i . sub` formats `sub` even if it is a nested git repository)
and no skip note is printed for them. Formatting a development checkout
such as `~/.julia/dev/MyPackage` is still allowed since only the
immediate depot subdirectories are protected.

The new `--recurse` flag includes nested git repositories in directory
walks. The new `--force-recurse` flag disables all checks (and implies
`--recurse`).

Fixes #200
