### PR TITLE
Add tests for multiline callable struct signatures

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1171,6 +1171,36 @@ end
     @test format_string("public a, b") == "public a, b" # Julia 1.11
 end
 
+# https://github.com/fredrikekre/Runic.jl/issues/153
+@testset "multiline callable struct signature" begin
+    @test format_string("function (::A)()\n    return 1\nend") ==
+        "function (::A)()\n    return 1\nend"
+    # A `function` signature with newlines inside the callee parentheses parses as an
+    # anonymous function with a tuple as the first expression of the body instead of
+    # as a call. Fixed upstream in JuliaSyntax#580; flip these to `@test` when a
+    # release including that fix is available.
+    @test_broken format_string("function (\n        ::A\n    )()\n    return 1\nend") ==
+        "function (\n        ::A\n    )()\n    return 1\nend"
+    str = """
+    function (
+            r::LowOrderMoment{
+                <:Any, <:Any, <:Any,
+                <:LowOrderDeviation{<:Any, <:SecondLowerMoment},
+            }
+        )(
+            w::AbstractVector,
+            X::AbstractMatrix,
+            fees::Union{
+                Nothing,
+                <:Fees,
+            } = nothing
+        )
+        return nothing
+    end
+    """
+    @test_broken format_string(str) == str
+end
+
 @testset "indent of multiline strings" begin
     for triple in ("\"\"\"", "```"), sp in ("", " ", "    "),
             (pre, post) in (("", ""), ("pre", ""), ("pre", "post"))


### PR DESCRIPTION
Regression tests for #153: a function signature with newlines inside the
callee parentheses parses as an anonymous function with a tuple body
instead of as a call, so the formatter split the `)(` and broke the
code. Fixed upstream in JuliaSyntax#580.

Closes #153.
