### PR TITLE
explicit return: don't add return when all branches throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ - The explicit `return` rule no longer adds `return` when the last expression of a
+   function is an `if`, `let`, `begin`, or ternary (`?:`) expression where all branches
+   terminate with a call to a function whose name is (or contains) `throw` or `error`
+   (for `if` this requires a trailing `else` since otherwise there is a fall-through path
+   that returns normally). This extends the existing exception for when the last expression
+   is a direct call to such a function. Note that already formatted code is not impacted by
+   this change since existing `return`s are kept as is. ([#202], [#217])
+
 ## [v1.9.0] - 2026-08-20
 ### Added
  - Formatting of Julia code in Quarto markdown files. Files with the `.qmd` extension are
@@ -284,9 +294,11 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#196]: https://github.com/fredrikekre/Runic.jl/issues/196
 [#197]: https://github.com/fredrikekre/Runic.jl/issues/197
 [#200]: https://github.com/fredrikekre/Runic.jl/issues/200
+[#202]: https://github.com/fredrikekre/Runic.jl/issues/202
 [#206]: https://github.com/fredrikekre/Runic.jl/issues/206
 [#207]: https://github.com/fredrikekre/Runic.jl/issues/207
 [#210]: https://github.com/fredrikekre/Runic.jl/issues/210
 [#211]: https://github.com/fredrikekre/Runic.jl/issues/211
 [#212]: https://github.com/fredrikekre/Runic.jl/issues/212
 [#213]: https://github.com/fredrikekre/Runic.jl/issues/213
+[#217]: https://github.com/fredrikekre/Runic.jl/issues/217

--- a/README.md
+++ b/README.md
@@ -726,7 +726,10 @@ Explicit `return` statements are ensured in function and macro definitions by ad
    functions (`(...) -> ...`), and `do`-blocks (`f(...) do ...; ...; end`).
  - If the last expression is a function call, and the function name is (or contains) `throw`
    or `error`, no `return` is added. This is because it is already obvious that these calls
-   terminate the function and don't return any value.
+   terminate the function and don't return any value. The same applies if the last
+   expression is an `if`, `let`, `begin`, or ternary (`?:`) expression where all branches
+   terminate with such a call (for `if` this requires a trailing `else` since otherwise
+   there is a fall-through path that returns normally).
 
 Note that adding `return` changes the expression in a way that is visible to macros.
 Therefore it is, in general, not valid to add `return` to a function defined inside a macro

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -3278,6 +3278,78 @@ function has_return(node::Node)
     end
 end
 
+# Check whether the expression always terminates by throwing an exception, based on the
+# heuristic that a call to a function whose name contains "throw" or "error" throws. In
+# addition to direct calls this also detects e.g. `if`s where all branches throw, see
+# https://github.com/fredrikekre/Runic.jl/issues/202. `pos` is the byte position of `node`
+# in `ctx.fmt_io` (the stream position is restored before returning).
+function always_throws(ctx::Context, node::Node, pos::Integer)
+    is_leaf(node) && return false
+    kids = verified_kids(node)
+    # Byte position of kids[i] in ctx.fmt_io
+    kidpos = function (i)
+        p = pos
+        for j in 1:(i - 1)
+            p += span(kids[j])
+        end
+        return p
+    end
+    if kind(node) === K"call"
+        fname_idx = findfirst(!JuliaSyntax.is_whitespace, kids)
+        fname_idx === nothing && return false
+        local fname
+        let p = position(ctx.fmt_io)
+            seek(ctx.fmt_io, kidpos(fname_idx))
+            fname = String(read_bytes(ctx, kids[fname_idx]))
+            seek(ctx.fmt_io, p)
+        end
+        return contains(fname, "throw") || contains(fname, "error")
+    elseif kind(node) === K"block"
+        # Check the trailing expression (skip the `begin`/`end` keywords of begin-blocks)
+        idx = findlast(x -> !(JuliaSyntax.is_whitespace(x) || kind(x) in KSet"begin end"), kids)
+        idx === nothing && return false
+        return always_throws(ctx, kids[idx], kidpos(idx))
+    elseif kind(node) in KSet"if elseif"
+        # All branch blocks (and nested elseifs) must throw and there must be a final
+        # `else` since otherwise there is a fall-through path that returns normally.
+        has_else = false
+        for i in eachindex(kids)
+            kid = kids[i]
+            if is_leaf(kid) && kind(kid) === K"else"
+                has_else = true
+            elseif !is_leaf(kid) && kind(kid) === K"elseif"
+                # The recursive call is responsible for requiring the trailing `else`
+                has_else = true
+                always_throws(ctx, kid, kidpos(i)) || return false
+            elseif kind(kid) === K"block" && !is_paren_block(kid)
+                always_throws(ctx, kid, kidpos(i)) || return false
+            end
+        end
+        return has_else
+    elseif kind(node) === K"let"
+        # The body is the second block kid (the first block holds the bindings)
+        idx = findfirst(x -> kind(x) === K"block", kids)
+        idx === nothing && return false
+        idx = findnext(x -> kind(x) === K"block", kids, idx + 1)
+        idx === nothing && return false
+        return always_throws(ctx, kids[idx], kidpos(idx))
+    elseif kind(node) === K"?"
+        # Both branches (the expressions after `?` and `:`) must throw
+        qidx = findfirst(x -> is_leaf(x) && kind(x) === K"?", kids)
+        qidx === nothing && return false
+        bidx1 = findnext(!JuliaSyntax.is_whitespace, kids, qidx + 1)
+        bidx1 === nothing && return false
+        cidx = findnext(x -> is_leaf(x) && kind(x) === K":", kids, bidx1 + 1)
+        cidx === nothing && return false
+        bidx2 = findnext(!JuliaSyntax.is_whitespace, kids, cidx + 1)
+        bidx2 === nothing && return false
+        return always_throws(ctx, kids[bidx1], kidpos(bidx1)) &&
+            always_throws(ctx, kids[bidx2], kidpos(bidx2))
+    else
+        return false
+    end
+end
+
 function explicit_return_block(ctx, node)
     @assert kind(node) === K"block"
     if has_return(node)
@@ -3306,20 +3378,11 @@ function explicit_return_block(ctx, node)
         for i in 1:(rexpr_idx - 1)
             accept_node!(ctx, kids′[i])
         end
-        # If this is a call node, and the call the function name contains `throw` or `error` we
-        # bail because `return throw(...)` looks kinda stupid.
-        if kind(rexpr) === K"call"
-            call_kids = verified_kids(rexpr)
-            fname_idx = findfirst(!JuliaSyntax.is_whitespace, call_kids)::Int
-            @assert fname_idx == firstindex(call_kids)
-            local fname
-            let p = position(ctx.fmt_io)
-                fname = String(read_bytes(ctx, call_kids[fname_idx]))
-                seek(ctx.fmt_io, p)
-            end
-            if contains(fname, "throw") || contains(fname, "error")
-                return nothing
-            end
+        # If the expression always throws, e.g. a call where the function name contains
+        # `throw` or `error`, or an `if` where all branches throw, we bail because e.g.
+        # `return throw(...)` looks kinda stupid.
+        if always_throws(ctx, rexpr, position(ctx.fmt_io))
+            return nothing
         end
         # We will make changes so copy
         kids′ = kids′ === kids ? copy(kids) : kids′

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1519,6 +1519,33 @@ end
         for r in ("throw(ArgumentError())", "error(\"foo\")", "rethrow()", "throw_error()")
             @test format_string("$f\n    $r\nend") == "$f\n    $r\nend"
         end
+        # If the last expression is an if/let/begin/? where all branches end in a call to
+        # throw/error there should be no return (issue #202)
+        for r in (
+                "if c\n        throw(A())\n    else\n        error(\"foo\")\n    end",
+                "if c\n        throw(A())\n    elseif d\n        rethrow()\n    else\n        error(\"foo\")\n    end",
+                "if c\n        x = 1\n        throw(A(x))\n    else\n        error(\"foo\")\n    end",
+                "c ? throw(A()) : error(\"foo\")",
+                "let x = 1\n        throw(A(x))\n    end",
+                "let\n        throw(A())\n    end",
+                "begin\n        throw(A())\n    end",
+                "if c\n        c ? throw(A()) : error(\"foo\")\n    else\n        let\n            error(\"foo\")\n        end\n    end",
+            )
+            @test format_string("$f\n    $r\nend") == "$f\n    $r\nend"
+        end
+        # ... but if there is a fall-through path or a branch that doesn't throw the
+        # return should still be added
+        for r in (
+                "if c\n        throw(A())\n    end",
+                "if c\n        throw(A())\n    elseif d\n        error(\"foo\")\n    end",
+                "if c\n        throw(A())\n    else\n        y\n    end",
+                "if c\n        x\n    else\n        error(\"foo\")\n    end",
+                "if c\n        throw(A())\n    elseif d\n        y\n    else\n        error(\"foo\")\n    end",
+                "c ? throw(A()) : y",
+                "c ? y : error(\"foo\")",
+            )
+            @test format_string("$f\n    $r\nend") == "$f\n    return $r\nend"
+        end
         # If the last expression is a macro call with return inside there should be no
         # return on the outside
         for r in (


### PR DESCRIPTION
The explicit return rule already skipped adding `return` when the
trailing expression is a call to a function whose name contains `throw`
or `error`. This patch generalizes this check to also cover
`if`/`let`/`begin`/`?` expressions where all branches end in such a
call, for example:

```julia
function f(x)
    if x < 0
        throw(DomainError(x))
    else
        error("nope")
    end
end
```

is now left alone instead of having the `if` wrapped in `return`. For
`if` a trailing `else` is required since otherwise there is a
fall-through path that returns normally.

Closes #202.
