### PR TITLE
Fix indentation of multiline element expressions in generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    that returns normally). This extends the existing exception for when the last expression
    is a direct call to such a function. Note that already formatted code is not impacted by
    this change since existing `return`s are kept as is. ([#202], [#217])
+### Fixed
+ - Multiline element expressions in generators (e.g. a multiline call or tuple before the
+   `for` keyword) no longer have their interior lines and closing token indented as
+   continuation lines. The closing token now aligns with the line of the opening token,
+   consistent with how such expressions are indented in e.g. operator call chains ([#173]).
 
 ## [v1.9.0] - 2026-08-20
 ### Added
@@ -284,6 +289,7 @@ First stable release of Runic.jl. See [README.md](README.md) for details and doc
 [#169]: https://github.com/fredrikekre/Runic.jl/issues/169
 [#170]: https://github.com/fredrikekre/Runic.jl/issues/170
 [#171]: https://github.com/fredrikekre/Runic.jl/issues/171
+[#173]: https://github.com/fredrikekre/Runic.jl/issues/173
 [#174]: https://github.com/fredrikekre/Runic.jl/issues/174
 [#175]: https://github.com/fredrikekre/Runic.jl/issues/175
 [#186]: https://github.com/fredrikekre/Runic.jl/issues/186

--- a/src/runestone.jl
+++ b/src/runestone.jl
@@ -2286,6 +2286,30 @@ function indent_iterator(ctx::Context, node::Node)
         # indentation via indent_op_call, so nothing to do here.
         return nothing
     end
+    if kind(node) === K"generator"
+        # Skip the element expression (the first kid): it starts the generator so its
+        # first line is not a continuation line and any newlines inside of it (e.g. a
+        # multiline call or tuple) are the responsibility of the expression itself,
+        # see https://github.com/fredrikekre/Runic.jl/issues/173.
+        kids = verified_kids(node)
+        elem_idx = findfirst(!JuliaSyntax.is_whitespace, kids)::Int
+        b = NodeBuilder(ctx, node)
+        for i in 1:elem_idx
+            accept!(b, kids[i])
+        end
+        for i in (elem_idx + 1):lastindex(kids)
+            kid = kids[i]
+            kid′ = continue_all_newlines(
+                ctx, kid; is_last = i == lastindex(kids), is_first = false
+            )
+            if kid′ === nothing
+                accept!(b, kid)
+            else
+                emit!(b, kid′)
+            end
+        end
+        return finish!(b, node)
+    end
     return continue_all_newlines(ctx, node)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -920,6 +920,19 @@ end
                 format_string("$(t)[$(sp)\n$(sp)a for a in b$(sp)]") ==
                 format_string("$(t)[$(sp)\n$(sp)a for a in b$(sp)\n$(sp)]") ==
                 "$(t)[\n    a for a in b\n]"
+            # https://github.com/fredrikekre/Runic.jl/issues/173
+            # Line break before `for` is a continuation line
+            @test format_string("$(t)[\n$(sp)a\n$(sp)for a in b\n$(sp)]") ==
+                "$(t)[\n    a\n        for a in b\n]"
+            @test format_string("$(t)[\n$(sp)a\n$(sp)for a in b\n$(sp)if a > c\n$(sp)]") ==
+                "$(t)[\n    a\n        for a in b\n        if a > c\n]"
+            # Multiline element expressions handle their own indentation
+            @test format_string("$(t)[\n$(sp)f(\n$(sp)a\n$(sp))\n$(sp)for a in b\n$(sp)]") ==
+                "$(t)[\n    f(\n        a\n    )\n        for a in b\n]"
+            @test format_string("$(t)[\n$(sp)f(\n$(sp)a\n$(sp)) for a in b\n$(sp)]") ==
+                "$(t)[\n    f(\n        a\n    ) for a in b\n]"
+            @test format_string("$(t)[\n$(sp)(\n$(sp)a, a^2,\n$(sp))\n$(sp)for a in b\n$(sp)]") ==
+                "$(t)[\n    (\n        a, a^2,\n    )\n        for a in b\n]"
         end
         # Single line begin-end
         @test format_string("begin x\n$(sp)end") == "begin\n    x\nend"


### PR DESCRIPTION
For a generator, `continue_all_newlines` tagged every newline in the
subtree as a continuation line, including newlines inside the element
expression. Since the element expression starts the generator its first
line is not a continuation line, so this extra indentation shifted the
interior and closing token of e.g. a multiline call or tuple relative
to its first line:

```julia
[
    sqrt(
            a
        ) for a in 1:5
]
```

Skip the element expression when tagging continuation lines and let it
handle its own newlines, like e.g. operands in operator call chains:

```julia
[
    sqrt(
        a
    ) for a in 1:5
]
```

A line break before the `for` keyword (and the rest of the generator)
is still treated as a continuation line as before.

Closes #173.
